### PR TITLE
Print accessible info on missing service account or metadata service unavailable

### DIFF
--- a/src/lib/credentials.py
+++ b/src/lib/credentials.py
@@ -63,9 +63,17 @@ async def create_default_service_account_token(session: ClientSession):
     :return:
     """
     url = _METADATA_ROOT + "/instance/service-accounts/{0}/token".format("default")
-    response = await session.get(url, headers=_METADATA_HEADERS)
-    response_json = await response.json()
-    return response_json["access_token"]
+    try:
+        response = await session.get(url, headers=_METADATA_HEADERS)
+        if response.status >= 300:
+            body = await response.text()
+            print(f"Failed to authorize with Service Account from Metadata Service, response is {response.status} => {body}")
+            return None
+        response_json = await response.json()
+        return response_json["access_token"]
+    except Exception as e:
+        print(f"Failed to authorize with Service Account from Metadata Service due to '{e}'")
+        return None
 
 
 def get_project_id_from_environment():

--- a/src/main.py
+++ b/src/main.py
@@ -69,6 +69,9 @@ async def handle_event(event: Dict, context: Dict, project_id: Optional[str]):
         setup_start_time = time.time()
         token = await create_token(session)
 
+        if token is None:
+            print("Cannot proceed without authorization token, stopping the execution")
+            return
         if not isinstance(token, str):
             raise Exception(f"Failed to fetch access token, got non string value: {token}")
 


### PR DESCRIPTION
This PR Improves log message on issues with default authorization, example:

````
Starting execution [2020-10-06T09:06:39.241935]
Trying to use default service account
Failed to authorize with Service Account from Metadata Service due to 'Cannot connect to host metadata.google.internal:80 ssl:default [getaddrinfo failed]'
Cannot proceed without authorization token, stopping the execution
Execution [2020-10-06T09:06:39.241935] took 1.2832658290863037
````