### PR TITLE
Improve logging for k8s deployments

### DIFF
--- a/src/lib/context.py
+++ b/src/lib/context.py
@@ -15,11 +15,25 @@
 import enum
 import os
 from datetime import datetime, timedelta
+from typing import Optional
 
 import aiohttp
 
 
-class Context:
+class LoggingContext:
+    def __init__(self, scheduled_execution_id: Optional[str]):
+        self.scheduled_execution_id: str = scheduled_execution_id[0:8] if scheduled_execution_id else None
+
+    def log(self, message: str):
+        timestamp_utc = datetime.utcnow()
+        timestamp_utc_iso = timestamp_utc.isoformat(sep=" ")
+        if self.scheduled_execution_id:
+            print(f"{timestamp_utc_iso} [{self.scheduled_execution_id}] : {message}")
+        else:
+            print(f"{timestamp_utc_iso} : {message}")
+
+
+class Context(LoggingContext):
     def __init__(
             self,
             session: aiohttp.ClientSession,
@@ -29,8 +43,11 @@ class Context:
             execution_interval_seconds: int,
             dynatrace_api_key: str,
             dynatrace_url: str,
-            print_metric_ingest_input: bool
+            print_metric_ingest_input: bool,
+            scheduled_execution_id: Optional[str]
     ):
+        super().__init__(scheduled_execution_id)
+
         self.session = session
         self.project_id = project_id
         self.url = "https://monitoring.googleapis.com/v3/projects/{name}/timeSeries".format(name=project_id)

--- a/src/lib/entities/decorator.py
+++ b/src/lib/entities/decorator.py
@@ -36,14 +36,14 @@ def entity_extractor(service_type: Text):
     def register_extractor(fun: ExtractEntitesFunc) -> ExtractEntitesFunc:
         @wraps(fun)
         async def get_and_upload(ctx: Context, svc_def: GCPService) -> Iterable[Entity]:
-            print("Starting download of metadata for service '{}'".format(svc_def.name))
+            ctx.log("Starting download of metadata for service '{}'".format(svc_def.name))
             try:
                 entities = await fun(ctx, svc_def)
             except Exception as e:
-                print(f"Failed to finish entity extractor task, reason is {type(e).__name__} {e}")
+                ctx.log(f"Failed to finish entity extractor task, reason is {type(e).__name__} {e}")
                 return []
 
-            print("Download of metadata for service '{}' finished".format(svc_def.name))
+            ctx.log("Download of metadata for service '{}' finished".format(svc_def.name))
 
             return entities
 

--- a/src/lib/entities/extractors/cloud_function.py
+++ b/src/lib/entities/extractors/cloud_function.py
@@ -91,4 +91,4 @@ async def get_cloud_function_entity(ctx: Context, svc_def: GCPService) -> Iterab
         project_id=ctx.project_id
     )
     mapper_func = partial(_cloud_function_resp_to_monitored_entities, svc_def=svc_def)
-    return await generic_paging(url, ctx.token, ctx.session, mapper_func)
+    return await generic_paging(url, ctx, mapper_func)

--- a/src/lib/entities/extractors/cloud_sql.py
+++ b/src/lib/entities/extractors/cloud_sql.py
@@ -66,4 +66,4 @@ async def get_cloud_sql_entity(ctx: Context, svc_def: GCPService) -> Iterable[En
         project_id=ctx.project_id
     )
     mapper_func = partial(_cloud_sql_resp_to_monitored_entities, svc_def=svc_def)
-    return await generic_paging(url, ctx.token, ctx.session, mapper_func)
+    return await generic_paging(url, ctx, mapper_func)

--- a/src/lib/entities/extractors/filestore_instance.py
+++ b/src/lib/entities/extractors/filestore_instance.py
@@ -93,4 +93,4 @@ async def get_filestore_instance_entity(ctx: Context, svc_def: GCPService) -> It
         project_id=ctx.project_id
     )
     mapper_func = partial(_filestore_instance_resp_to_monitored_entities, svc_def=svc_def)
-    return await generic_paging(url, ctx.token, ctx.session, mapper_func)
+    return await generic_paging(url, ctx, mapper_func)

--- a/src/lib/entities/extractors/gce_instance.py
+++ b/src/lib/entities/extractors/gce_instance.py
@@ -117,7 +117,7 @@ async def get_cloud_function_entity(ctx: Context, svc_def: GCPService) -> Iterab
     for zone in zones:
         url = f"https://compute.googleapis.com/compute/v1/projects/{ctx.project_id}/zones/{zone}/instances"
         mapper_func = partial(_cloud_function_resp_to_monitored_entities, svc_def=svc_def)
-        tasks.append(generic_paging(url, ctx.token, ctx.session, mapper_func))
+        tasks.append(generic_paging(url, ctx, mapper_func))
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     all_results = []

--- a/src/lib/entities/extractors/pubsub_subscription.py
+++ b/src/lib/entities/extractors/pubsub_subscription.py
@@ -86,4 +86,4 @@ async def get_cloud_function_entity(ctx: Context, svc_def: GCPService) -> Iterab
         project_id=ctx.project_id
     )
     mapper_func = partial(_cloud_function_resp_to_monitored_entities, svc_def=svc_def)
-    return await generic_paging(url, ctx.token, ctx.session, mapper_func)
+    return await generic_paging(url, ctx, mapper_func)

--- a/src/lib/self_monitoring.py
+++ b/src/lib/self_monitoring.py
@@ -23,7 +23,7 @@ from lib.metric_descriptor import SELF_MONITORING_METRIC_PREFIX, SELF_MONITORING
 
 async def push_self_monitoring_time_series(context: Context):
     try:
-        print(f"Pushing self monitoring time series to GCP Monitor...")
+        context.log(f"Pushing self monitoring time series to GCP Monitor...")
         await create_metric_descriptors_if_missing(context)
 
         time_series = create_self_monitoring_time_series(context)
@@ -36,12 +36,12 @@ async def push_self_monitoring_time_series(context: Context):
         status = self_monitoring_response.status
         if status != 200:
             self_monitoring_response_json = await self_monitoring_response.json()
-            print(f"Failed to push self monitoring time series, error is: {status} => {self_monitoring_response_json}")
+            context.log(f"Failed to push self monitoring time series, error is: {status} => {self_monitoring_response_json}")
         else:
-            print(f"Finished pushing self monitoring time series to GCP Monitor")
+            context.log(f"Finished pushing self monitoring time series to GCP Monitor")
         self_monitoring_response.close()
     except Exception as e:
-        print(f"Failed to push self monitoring time series, reason is {type(e).__name__} {e}")
+        context.log(f"Failed to push self monitoring time series, reason is {type(e).__name__} {e}")
 
 
 async def create_metric_descriptors_if_missing(context: Context):
@@ -56,7 +56,7 @@ async def create_metric_descriptors_if_missing(context: Context):
         types = [metric.get("type", "") for metric in dynatrace_metrics_descriptors_json.get("metricDescriptors", [])]
         for metric_type, metric_descriptor in SELF_MONITORING_METRIC_MAP.items():
             if metric_type not in types:
-                print(f"Creating missing metric descriptor for '{metric_type}'")
+                context.log(f"Creating missing metric descriptor for '{metric_type}'")
                 await context.session.request(
                     "POST",
                     url=f"https://monitoring.googleapis.com/v3/projects/{context.project_id}/metricDescriptors",
@@ -64,7 +64,7 @@ async def create_metric_descriptors_if_missing(context: Context):
                     headers={"Authorization": f"Bearer {context.token}"}
                 )
     except Exception as e:
-        print(f"Failed to create self monitoring metrics descriptors, reason is {type(e).__name__} {e}")
+        context.log(f"Failed to create self monitoring metrics descriptors, reason is {type(e).__name__} {e}")
 
 
 def create_time_serie(

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@
 #     limitations under the License.
 
 import asyncio
+import hashlib
 import os
 import time
 import traceback
@@ -24,7 +25,7 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 import yaml
 
-from lib.context import Context
+from lib.context import Context, LoggingContext
 from lib.credentials import create_token, get_project_id_from_environment, fetch_dynatrace_api_key, fetch_dynatrace_url
 from lib.entities import entities_extractors
 from lib.entities.model import Entity
@@ -44,14 +45,21 @@ def dynatrace_gcp_extension(event, context: Dict[Any, Any] = None, project_id: O
 async def async_dynatrace_gcp_extension():
     timestamp_utc = datetime.utcnow()
     timestamp_utc_iso = timestamp_utc.isoformat()
-    print(f"\nStarting execution [{timestamp_utc_iso}]")
-    context = {'timestamp': timestamp_utc_iso, 'event_id': timestamp_utc.timestamp(), 'event_type': 'test'}
+    execution_identifier = hashlib.md5(timestamp_utc_iso.encode("UTF-8")).hexdigest()
+    logging_context = LoggingContext(execution_identifier)
+    logging_context.log(f"Starting execution")
+    context = {
+        'timestamp': timestamp_utc_iso,
+        'event_id': timestamp_utc.timestamp(),
+        'event_type': 'test',
+        'execution_id': execution_identifier
+    }
     data = {'data': '', 'publishTime': timestamp_utc_iso}
 
     start_time = time.time()
     await handle_event(data, context, "dynatrace-gcp-extension")
     elapsed_time = time.time() - start_time
-    print(f"Execution [{timestamp_utc_iso}] took {elapsed_time}")
+    logging_context.log(f"Execution took {elapsed_time}\n")
 
 
 def is_yaml_file(f: str) -> bool:
@@ -59,23 +67,25 @@ def is_yaml_file(f: str) -> bool:
 
 
 async def handle_event(event: Dict, context: Dict, project_id: Optional[str]):
+    context = LoggingContext(context.get("execution_id", None))
+
     selected_services = None
     if "GCP_SERVICES" in os.environ:
         selected_services_string = os.environ.get("GCP_SERVICES", "")
         selected_services = selected_services_string.split(",") if selected_services_string else []
-    services = load_supported_services(selected_services)
+    services = load_supported_services(context, selected_services)
 
     async with aiohttp.ClientSession() as session:
         setup_start_time = time.time()
-        token = await create_token(session)
+        token = await create_token(context, session)
 
         if token is None:
-            print("Cannot proceed without authorization token, stopping the execution")
+            context.log("Cannot proceed without authorization token, stopping the execution")
             return
         if not isinstance(token, str):
             raise Exception(f"Failed to fetch access token, got non string value: {token}")
 
-        print("Successfully obtained access token")
+        context.log("Successfully obtained access token")
 
         if not project_id:
             project_id = get_project_id_from_environment()
@@ -94,7 +104,8 @@ async def handle_event(event: Dict, context: Dict, project_id: Optional[str]):
             execution_interval_seconds=60 * 1,
             dynatrace_api_key=dynatrace_api_key,
             dynatrace_url=dynatrace_url,
-            print_metric_ingest_input=print_metric_ingest_input
+            print_metric_ingest_input=print_metric_ingest_input,
+            scheduled_execution_id=context.scheduled_execution_id
         )
         context.setup_execution_time = (time.time() - setup_start_time)
 
@@ -121,7 +132,7 @@ async def handle_event(event: Dict, context: Dict, project_id: Optional[str]):
         fetch_topology_results = all_results[1]
 
         context.fetch_gcp_data_execution_time = time.time() - fetch_gcp_data_start_time
-        print(f"Fetched GCP data in {context.fetch_gcp_data_execution_time} s")
+        context.log(f"Fetched GCP data in {context.fetch_gcp_data_execution_time} s")
 
         entity_id_map = build_entity_id_map(fetch_topology_results)
         flat_metric_results = flatten_and_enrich_metric_results(fetch_metric_results, entity_id_map)
@@ -142,7 +153,7 @@ def build_entity_id_map(fetch_topology_results: List[List[Entity]]) -> Dict[str,
     return result
 
 
-def load_supported_services(selected_services: List[str]) -> List[GCPService]:
+def load_supported_services(context: LoggingContext, selected_services: List[str]) -> List[GCPService]:
     working_directory = os.path.dirname(os.path.realpath(__file__))
     config_directory = os.path.join(working_directory, "config")
     config_files = [
@@ -166,7 +177,7 @@ def load_supported_services(selected_services: List[str]) -> List[GCPService]:
                         continue
                     services.append(GCPService(tech_name=technology_name, **service_yaml))
         except Exception as error:
-            print(f"Failed to load configuration file: '{config_file_path}'. Error details: {error}")
+            context.log(f"Failed to load configuration file: '{config_file_path}'. Error details: {error}")
             continue
     return services
 
@@ -179,5 +190,5 @@ async def run_fetch_metric(
     try:
         return await fetch_metric(context, service, metric)
     except Exception as e:
-        print(f"Failed to finish task for [{metric.google_metric}], reason is {type(e).__name__} {e}")
+        context.log(f"Failed to finish task for [{metric.google_metric}], reason is {type(e).__name__} {e}")
         return []

--- a/src/run_docker.py
+++ b/src/run_docker.py
@@ -14,6 +14,7 @@
 import asyncio
 import os
 
+from lib.context import LoggingContext
 from main import async_dynatrace_gcp_extension
 
 
@@ -47,15 +48,15 @@ print("  ,     ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,  ,,,,,,,")
 print("     ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,  ,,,,")
 print("")
 
+logging_context = LoggingContext(None)
 
-print("Dynatrace function for Google Cloud Platform monitoring")
-print("")
+logging_context.log("Dynatrace function for Google Cloud Platform monitoring\n")
 
 if "GCP_SERVICES" in os.environ:
     services = os.environ.get("GCP_SERVICES", "")
     print(f"Running with configured services: {services}")
 
-print("Setting up..")
+logging_context.log("Setting up... \n")
 loop = asyncio.get_event_loop()
 loop.create_task(scheduling_loop())
 loop.run_forever()


### PR DESCRIPTION
Log messages are prefixed with UTC ISO datetime string and execution identifier in `[]`. Example output: 
````
                      ,,,,,..
                  ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,.
               ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
            .,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,     ,,
          ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,    .,,,,
       ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,     ,,,,,,,.
    .,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,.    ,,,,,,,,,,,
  ,,,,,,,,,,,,,,,,,......  ......,,,,,,,    .,,,,,,,,,,,,,
,,                                        ,,,,,,,,,,,,,,,,
,,,,,,,,,,,,,,,,,                        .,,,,,,,,,,,,,,,,
,,,,,,,,,,,,,,,,,                        .,,,,,,,,,,,,,,,,.
,,,,,,,,,,,,,,,,,       Dynatrace        .,,,,,,,,,,,,,,,,.
,,,,,,,,,,,,,,,,, dynatrace-gcp-function .,,,,,,,,,,,,,,,,,
,,,,,,,,,,,,,,,,,                        .,,,,,,,,,,,,,,,,,
,,,,,,,,,,,,,,,,,                        ,,,,,,,,,,,,,,,,,,
,,,,,,,,,,,,,,,,,                        ,,,,,,,,,,,,,,,,,,
.,,,,,,,,,,,,,,,                         ,,,,,,,,,,,,,,,,,
.,,,,,,,,,,,,,    .,,,,,,,,,,,,,,,,,,.   ,,,,,,,,,,,,,,,
 ,,,,,,,,,,     ,,,,,,,,,,,,,,,,,,,,,,  .,,,,,,,,,,,,.
 ,,,,,,,     ,,,,,,,,,,,,,,,,,,,,,,,,,  ,,,,,,,,,,,
 ,,,,,    .,,,,,,,,,,,,,,,,,,,,,,,,,,.  ,,,,,,,,
  ,     ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,  ,,,,,,,
     ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,  ,,,,

2020-10-27 06:47:15.409391 : Dynatrace function for Google Cloud Platform monitoring

2020-10-27 06:47:15.409391 : Setting up... 

2020-10-27 06:47:15.409391 [cb6e09d6] : Starting execution
2020-10-27 06:47:16.450389 [cb6e09d6] : Using credentials from C:\workspaces\gcp-ext-sa.json
2020-10-27 06:47:16.852118 [cb6e09d6] : Successfully obtained access token
2020-10-27 06:47:17.768371 [cb6e09d6] : Starting download of metadata for service 'cloudsql_database'
2020-10-27 06:47:17.768371 [cb6e09d6] : Starting download of metadata for service 'cloud_function'
2020-10-27 06:47:17.768371 [cb6e09d6] : Starting download of metadata for service 'filestore_instance'
2020-10-27 06:47:17.768371 [cb6e09d6] : Starting download of metadata for service 'gce_instance'
2020-10-27 06:47:17.769371 [cb6e09d6] : Starting download of metadata for service 'pubsub_subscription'
2020-10-27 06:47:19.816282 [cb6e09d6] : Download of metadata for service 'cloud_function' finished
2020-10-27 06:47:19.978516 [cb6e09d6] : Download of metadata for service 'filestore_instance' finished
2020-10-27 06:47:20.073230 [cb6e09d6] : Download of metadata for service 'pubsub_subscription' finished
2020-10-27 06:47:20.135849 [cb6e09d6] : Download of metadata for service 'cloudsql_database' finished
2020-10-27 06:47:21.446219 [cb6e09d6] : Download of metadata for service 'gce_instance' finished
2020-10-27 06:47:23.205493 [cb6e09d6] : Fetched GCP data in 5.592122554779053 s
2020-10-27 06:47:24.725566 [cb6e09d6] : Ingest response: {'linesOk': 1000, 'linesInvalid': 0, 'error': None}
2020-10-27 06:47:24.907950 [cb6e09d6] : Ingest response: {'linesOk': 166, 'linesInvalid': 0, 'error': None}
2020-10-27 06:47:24.907950 [cb6e09d6] : Finished uploading metric ingest lines to Dynatrace in 1.6774365901947021 s
2020-10-27 06:47:24.907950 [cb6e09d6] : Pushing self monitoring time series to GCP Monitor...
2020-10-27 06:47:25.228072 [cb6e09d6] : Finished pushing self monitoring time series to GCP Monitor
2020-10-27 06:47:25.242058 [cb6e09d6] : Execution took 9.832667112350464
````