### PR TITLE
fix for dynatrace manged urls

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -112,12 +112,12 @@ s)
 esac
 
 echo "Please provide the URL used to access Dynatrace, for example: https://mytenant.live.dynatrace.com/"
-while ! [[ "${DYNATRACE_URL}" =~ ^https?:\/\/[-a-zA-Z0-9@:%._+~=]{1,256}\/$ ]]; do
+while ! [[ "${DYNATRACE_URL}" =~ ^(https?:\/\/[-a-zA-Z0-9@:%._+~=]{1,256}\/)(e\/[a-z0-9-]{36}\/)?$ ]]; do
     read -p "Enter Dynatrace tenant URI: " DYNATRACE_URL
 done
 echo ""
 
-echo "Please log in to Dynatrace, and generate API token (Settings->Integration->Dynatrace API). The token requires grant of 'API v2 Ingest metrics', 'API v1 Read configuration' and `WriteConfig` scope"
+echo "Please log in to Dynatrace, and generate API token (Settings->Integration->Dynatrace API). The token requires grant of 'API v2 Ingest metrics', 'API v1 Read configuration' and 'WriteConfig' scope"
 while ! [[ "${DYNATRACE_ACCESS_KEY}" != "" ]]; do
     read -p "Enter Dynatrace API token: " DYNATRACE_ACCESS_KEY  
 done

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -59,7 +59,7 @@ async def _push_to_dynatrace(context: Context, lines_batch: List[IngestLine]):
         context.log("Ingest input is: ")
         context.log(ingest_input)
     ingest_response = await context.session.post(
-        url=urljoin(context.dynatrace_url, "/api/v2/metrics/ingest"),
+        url=f"{context.dynatrace_url}/api/v2/metrics/ingest",
         headers={
             "Authorization": f"Api-Token {context.dynatrace_api_key}",
             "Content-Type": "text/plain; charset=utf-8"

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -59,7 +59,7 @@ async def _push_to_dynatrace(context: Context, lines_batch: List[IngestLine]):
         context.log("Ingest input is: ")
         context.log(ingest_input)
     ingest_response = await context.session.post(
-        url=f"{context.dynatrace_url}/api/v2/metrics/ingest",
+        url=f"{context.dynatrace_url.rstrip('/')}}/api/v2/metrics/ingest",
         headers={
             "Authorization": f"Api-Token {context.dynatrace_api_key}",
             "Content-Type": "text/plain; charset=utf-8"

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -59,7 +59,7 @@ async def _push_to_dynatrace(context: Context, lines_batch: List[IngestLine]):
         context.log("Ingest input is: ")
         context.log(ingest_input)
     ingest_response = await context.session.post(
-        url=f"{context.dynatrace_url.rstrip('/')}}/api/v2/metrics/ingest",
+        url=f"{context.dynatrace_url.rstrip('/')}/api/v2/metrics/ingest",
         headers={
             "Authorization": f"Api-Token {context.dynatrace_api_key}",
             "Content-Type": "text/plain; charset=utf-8"


### PR DESCRIPTION
Fix to support URL's in Dynatrace managed format: https://abcd.managed-dt.dynalabs.io/e/ett29184-1ae2-46dd-96fe-02957773fc57/ 
Using urljoin removes all URL segments .. :(