### PR TITLE
APM-264620: DDU estimation script

### DIFF
--- a/generate_ddu_estimation.py
+++ b/generate_ddu_estimation.py
@@ -1,0 +1,39 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+from lib.context import LoggingContext
+from main import load_supported_services
+
+DATA_POINT_WEIGHT = 0.001
+DECIMAL_PLACES = 3
+ASSUMED_AVG_DIMENSION_VALUES = 3
+
+
+def generate_ddu_estimation():
+    supported_services = load_supported_services(LoggingContext(None), [])
+    print("|| name || data points rate (/min) || estimated DDU rate (/min) (1 data point = 0.001 DDU)||")
+    for supported_service in supported_services:
+        data_points_per_minute = 0
+
+        for metric in supported_service.metrics:
+            dimensions_multiplier = (ASSUMED_AVG_DIMENSION_VALUES ** len(metric.dimensions))
+            rate_per_minute = (metric.sample_period_seconds.seconds / 60.0)
+            data_points_per_minute += rate_per_minute * dimensions_multiplier
+
+        ddu_estimation = round(data_points_per_minute * DATA_POINT_WEIGHT, DECIMAL_PLACES)
+        data_points_rate_estimation = round(data_points_per_minute, 0)
+        print(f"| {supported_service.name} | {data_points_rate_estimation} | {ddu_estimation} |")
+
+
+if __name__ == "__main__":
+    generate_ddu_estimation()


### PR DESCRIPTION
Output is a JIRA markdown table:

````
|| name || data points rate (/min) || estimated DDU rate (/min) (1 data point = 0.001 DDU)||
| api | 86.0 | 0.086 |
| cloudsql_database | 66.0 | 0.066 |
| cloud_function | 73.0 | 0.073 |
| datastore_request | 24.0 | 0.024 |
| filestore_instance | 48.0 | 0.048 |
| gce_instance | 2287332170205.0 | 2287332170.205 |
| gcs_bucket | 185.0 | 0.185 |
| https_lb_rule | 3897.0 | 3.897 |
| internal_http_lb_rule | 405.0 | 0.405 |
| internal_tcp_lb_rule | 135.0 | 0.135 |
| internal_udp_lb_rule | 108.0 | 0.108 |
| tcp_lb_rule | 45.0 | 0.045 |
| udp_lb_rule | 36.0 | 0.036 |
| pubsub_snapshot | 21.0 | 0.021 |
| pubsub_subscription | 166.0 | 0.166 |
| pubsub_topic | 49.0 | 0.049 |
| pubsublite_topic_partition | 10.0 | 0.01 |
````

Estimation for `gce_instance` is ridiculous, because it contains a lot of agent metrics (343 in sum) and some of them have up to 19 dimensions.