### PR TITLE
APM-290460: Logging improvements and SERVICE_USAGE_BOOKING flag sanitization

### DIFF
--- a/src/lib/context.py
+++ b/src/lib/context.py
@@ -86,6 +86,8 @@ class Context(LoggingContext):
         self.dynatrace_request_count = {}
         self.dynatrace_connectivity = DynatraceConnectivity.Ok
 
+        self.gcp_metric_request_count = {}
+
         self.dynatrace_ingest_lines_ok_count = {}
         self.dynatrace_ingest_lines_invalid_count = {}
         self.dynatrace_ingest_lines_dropped_count = {}

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -31,7 +31,7 @@ async def push_ingest_lines(context: Context, project_id: str, fetch_metric_resu
         return
 
     if not fetch_metric_results:
-        context.log(project_id, "Skipping push due to detected connectivity error")
+        context.log(project_id, "Skipping push due to no data to push")
 
     lines_sent = 0
     maximum_lines_threshold = context.maximum_metric_data_points_per_minute

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -155,6 +155,8 @@ async def fetch_metric(
 
     lines = []
     while should_fetch:
+        context.gcp_metric_request_count[project_id] = context.gcp_metric_request_count.get(project_id, 0) + 1
+
         url = f"https://monitoring.googleapis.com/v3/projects/{project_id}/timeSeries"
         resp = await context.gcp_session.request('GET', url=url, params=params, headers=headers)
         page = await resp.json()

--- a/src/lib/self_monitoring.py
+++ b/src/lib/self_monitoring.py
@@ -21,7 +21,19 @@ from lib.metric_descriptor import SELF_MONITORING_METRIC_PREFIX, SELF_MONITORING
     SELF_MONITORING_REQUEST_COUNT_METRIC_TYPE, SELF_MONITORING_PHASE_EXECUTION_TIME_METRIC_TYPE
 
 
+def log_self_monitoring_data(context: Context):
+    context.log("SFM", f"GCP Monitoring API request count [per project]: {context.gcp_metric_request_count}")
+    context.log("SFM", f"Dynatrace MINT API request count [per response code]: {context.dynatrace_request_count}")
+    context.log("SFM", f"Dynatrace MINT accepted lines count [per project]: {context.dynatrace_ingest_lines_ok_count}")
+    context.log("SFM", f"Dynatrace MINT invalid lines count [per project]: {context.dynatrace_ingest_lines_invalid_count}")
+    context.log("SFM", f"Dynatrace MINT dropped lines count [per project]: {context.dynatrace_ingest_lines_dropped_count}")
+    context.log("SFM", f"Setup execution time: {context.setup_execution_time.get(context.project_id_owner, None)}") # values are the same for all projects
+    context.log("SFM", f"Fetch GCP data execution time [per project]: {context.fetch_gcp_data_execution_time}")
+    context.log("SFM", f"Push data to Dynatrace execution time [per project]: {context.push_to_dynatrace_execution_time}")
+
+
 async def push_self_monitoring_time_series(context: Context, is_retry: bool = False):
+    log_self_monitoring_data(context)
     try:
         context.log(f"Pushing self monitoring time series to GCP Monitor...")
         await create_metric_descriptors_if_missing(context)


### PR DESCRIPTION
Changes:
- Configuration flags are printed on the startup
- Additional log messages have been added on service booking check, to improve visibility of what kind of booking is used
- `SERVICE_USAGE_BOOKING` value is sanitized before checking for equality with `destination` to avoid any mismatches with leading whitespaces etc.
- FastCheck check for Dynatrace connectivity was performed for each configured project, which makes no sense as function uses single set of credentials. Now it is performed once.
- Printing out SFM data has been added as most users are not permitting the function to create SFM metrics.
- `gcp_metric_request_count` is not sent to GCP Monitor metrics yet - that requires deeper consideration of dimensions and documentation update, I've decided it is out of scope of this PR (which is mainly meant to allow us to help customer with their throttling issues) and will be done in future improvement PR.


Example logs:

````
2021-03-19 06:49:49.687583  : Dynatrace function for Google Cloud Platform monitoring

2021-03-19 06:49:49.687583  : Setting up... 

2021-03-19 06:49:49.687583  : Using Dynatrace endpoint: https://jxw01498.dev.dynatracelabs.com
2021-03-19 06:49:50.432833  : Missing ReadConfig/WriteConfig permission for Dynatrace API token, skipping dashboards configuration
2021-03-19 06:49:50.433833  : Using credentials from C:\workspaces\dynatrace-gcp-extension-0435c3647627.json
2021-03-19 06:49:50.963341  : Found configuration flags: PRINT_METRIC_INGEST_INPUT = 'false', GOOGLE_APPLICATION_CREDENTIALS = 'C:\workspaces\dynatrace-gcp-extension-0435c3647627.json', MAXIMUM_METRIC_DATA_POINTS_PER_MINUTE is None, METRIC_INGEST_BATCH_SIZE is None, REQUIRE_VALID_CERTIFICATE is None, SERVICE_USAGE_BOOKING = 'destination', USE_PROXY is None
2021-03-19 06:49:52.173823  : Access to following projects: dynatrace-gcp-extension-prod, dynatrace-gcp-extension
2021-03-19 06:49:54.796230  : Monitoring enabled for the following projects: FastCheckResult(projects=['dynatrace-gcp-extension-prod', 'dynatrace-gcp-extension'])
2021-03-19 06:49:55.989225  : Local deployment detected. Skipped instance metadata info, the reason is: [Errno 11001] getaddrinfo failed
2021-03-19 06:49:55.991227 [c58301f4] : Starting execution for project(s): ['dynatrace-gcp-extension-prod', 'dynatrace-gcp-extension']
2021-03-19 06:49:58.343701 [c58301f4] : Selected feature sets: api/default,apigee.googleapis.com/Environment/default,apigee.googleapis.com/Proxy/default,apigee.googleapis.com/ProxyV2/default,assistant_action_project/default,autoscaler/default,bigquery_biengine_model/default,bigquery_project/default,bigtable_cluster/default,bigtable_table/default,cloudiot_device_registry/default,cloudml_job/default,cloudml_model_version/default,cloudsql_database/default,cloudtrace.googleapis.com/CloudtraceProject/default,cloudvolumesgcp-api.netapp.com/NetAppCloudVolumeSO/default,cloud_composer_environment/default,cloud_dataproc_cluster/default,cloud_dlp_project/default,cloud_function/default,cloud_run_revision/default,cloud_tasks_queue/default,consumed_api/default,consumer_quota/default,dataflow_job/default,datastore_request/default,dns_query/default,filestore_instance/default,firebase_domain/default,firebase_namespace/default,firestore_instance/default,gae_app/default,gae_app_uptime_check/default,gae_instance/default,gce_instance/default,gce_instance/agent,gce_instance/appenginee,gce_instance/firewallinsights,gce_instance/istio,gce_instance/uptime_check,gce_instance_vm_flow/,gce_router/default,gce_zone_network_health/default,gcs_bucket/default,gke_container/default,https_lb_rule/default,instance_group/default,interconnect/default,interconnect_attachment/default,internal_http_lb_rule/default,internal_tcp_lb_rule/default,internal_udp_lb_rule/default,istio_canonical_service/default,k8s_cluster/default,k8s_container/default,k8s_container/agent,k8s_container/apigee,k8s_container/istio,k8s_container/nginx,k8s_node/default,k8s_pod/default,k8s_pod/istio,knative_broker/default,knative_revision/default,knative_trigger/default,logging_sink/default,microsoft_ad_domain/default,nat_gateway/default,netapp_cloud_volume/default,network_security_policy/default,producer_quota/default,pubsublite_subscription_partition/default,pubsublite_topic_partition/default,pubsub_snapshot/default,pubsub_subscription/default,pubsub_topic/default,recaptchaenterprise.googleapis.com/Key/default,redis_instance/default,spanner_instance/default,tcp_lb_rule/default,tcp_ssl_proxy_rule/default,tpu_worker/default,transfer_service_agent/default,udp_lb_rule/default,uptime_url/default,vpc_access_connector/default,vpn_gatewayv/
2021-03-19 06:49:58.343701 [c58301f4] : Using credentials from C:\workspaces\dynatrace-gcp-extension-0435c3647627.json
2021-03-19 06:49:58.670700 [c58301f4] : Successfully obtained access token
2021-03-19 06:49:58.670700 [c58301f4] [dynatrace-gcp-extension-prod] : Starting processing...
2021-03-19 06:49:58.671701 [c58301f4] [dynatrace-gcp-extension] : Starting processing...
2021-03-19 06:49:59.463962 [c58301f4] [dynatrace-gcp-extension-prod] : Using SERVICE_USAGE_BOOKING = destination
2021-03-19 06:50:04.649951 [c58301f4] [dynatrace-gcp-extension-prod] : Skipped fetching metrics for cloudsql_database, cloud_function, filestore_instance, gce_instance, gce_instance, gce_instance, gce_instance, gce_instance, gce_instance, pubsub_subscription due to no instances detected
2021-03-19 06:50:07.578797 [c58301f4] [dynatrace-gcp-extension] : Finished fetching data in 8.9080970287323
2021-03-19 06:50:08.549907 [c58301f4] [dynatrace-gcp-extension-prod] : Finished fetching data in 9.87920618057251
2021-03-19 06:50:09.092908 [c58301f4] [dynatrace-gcp-extension] : Ingest response: {'linesOk': 1000, 'linesInvalid': 0, 'error': None}
2021-03-19 06:50:09.394897 [c58301f4] [dynatrace-gcp-extension-prod] : Ingest response: {'linesOk': 74, 'linesInvalid': 0, 'error': None}
2021-03-19 06:50:09.394897 [c58301f4] [dynatrace-gcp-extension-prod] : Finished uploading metric ingest lines to Dynatrace in 0.8449904918670654 s
2021-03-19 06:50:09.673906 [c58301f4] [dynatrace-gcp-extension] : Ingest response: {'linesOk': 1000, 'linesInvalid': 0, 'error': None}
2021-03-19 06:50:10.225909 [c58301f4] [dynatrace-gcp-extension] : Ingest response: {'linesOk': 1000, 'linesInvalid': 0, 'error': None}
2021-03-19 06:50:10.690909 [c58301f4] [dynatrace-gcp-extension] : Ingest response: {'linesOk': 1000, 'linesInvalid': 0, 'error': None}
2021-03-19 06:50:11.006899 [c58301f4] [dynatrace-gcp-extension] : Ingest response: {'linesOk': 283, 'linesInvalid': 0, 'error': None}
2021-03-19 06:50:11.006899 [c58301f4] [dynatrace-gcp-extension] : Finished uploading metric ingest lines to Dynatrace in 3.4281013011932373 s
2021-03-19 06:50:11.009898 [c58301f4] : Fetched and pushed GCP data in 12.339197397232056 s
2021-03-19 06:50:11.009898 [c58301f4] [SFM] : GCP Monitoring API request count [per project]: {'dynatrace-gcp-extension': 1065, 'dynatrace-gcp-extension-prod': 635}
2021-03-19 06:50:11.009898 [c58301f4] [SFM] : Dynatrace MINT API request count [per response code]: {202: 6}
2021-03-19 06:50:11.009898 [c58301f4] [SFM] : Dynatrace MINT accepted lines count [per project]: {'dynatrace-gcp-extension': 4283, 'dynatrace-gcp-extension-prod': 74}
2021-03-19 06:50:11.009898 [c58301f4] [SFM] : Dynatrace MINT invalid lines count [per project]: {'dynatrace-gcp-extension': 0, 'dynatrace-gcp-extension-prod': 0}
2021-03-19 06:50:11.009898 [c58301f4] [SFM] : Dynatrace MINT dropped lines count [per project]: {}
2021-03-19 06:50:11.009898 [c58301f4] [SFM] : Setup execution time: 0.3269994258880615
2021-03-19 06:50:11.009898 [c58301f4] [SFM] : Fetch GCP data execution time [per project]: {'dynatrace-gcp-extension': 8.9080970287323, 'dynatrace-gcp-extension-prod': 9.87920618057251}
2021-03-19 06:50:11.009898 [c58301f4] [SFM] : Push data to Dynatrace execution time [per project]: {'dynatrace-gcp-extension-prod': 0.8449904918670654, 'dynatrace-gcp-extension': 3.4281013011932373}
2021-03-19 06:50:11.009898 [c58301f4] : Pushing self monitoring time series to GCP Monitor...
2021-03-19 06:50:11.414557 [c58301f4] : Finished pushing self monitoring time series to GCP Monitor
2021-03-19 06:50:11.428541 [c58301f4] : Execution took 15.437313556671143
````