### PR TITLE
APM-292194: Run Logs POC in container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ notifications:
   email:
     on_success: never
 stages:
+- tests
 - docker-build
 - github-deploy
 env:
@@ -13,6 +14,20 @@ env:
   - DOCKER_CLI_EXPERIMENTAL=enabled
 jobs:
   include:
+  - stage: tests
+    name: Tests
+    language: python
+    python:
+      - "3.8"
+    install:
+      - pip install -r src/requirements.txt
+      - pip install -r tests/requirements.txt
+    addons:
+      apt:
+        packages:
+          - default-jre
+    script:
+      - PYTHONPATH="./src" pytest tests/integration -v
   - stage: docker-build
     name: Docker build
     language: minimal

--- a/HACKING.md
+++ b/HACKING.md
@@ -41,5 +41,5 @@ Worker function execution can be tweaked with environment variables. In Google F
 | DYNATRACE_LOG_INGEST_CONTENT_MAX_LENGTH | determines max content length of log event. Should be the same or lower than on cluster | 8192 characters |
 | DYNATRACE_LOG_INGEST_EVENT_MAX_AGE_SECONDS | Determines max age of forwarded log event. Should be the same or lower than on cluster | 1 day |
 | LOGS_SUBSCRIPTION_PROJECT | GCP project of log sink pubsub subscription | |
-| SUBSCRIPTION_ID | subscription id of log sink pubsub subscription | |
+| LOGS_SUBSCRIPTION_ID | subscription id of log sink pubsub subscription | |
 | DYNATRACE_LOG_INGEST_SENDING_WORKER_EXECUTION_PERIOD | Period of sending batched logs to Dynatrace | 60 seconds |

--- a/HACKING.md
+++ b/HACKING.md
@@ -15,6 +15,8 @@ To run worker function run `local_test.py` script file.
 
 Worker function execution can be tweaked with environment variables. In Google Function you can input them when deploying/editing the function:
 
+### Metric processing configuration variables
+
 | Variable name | description   | default value |
 | ----------------- | ------------- | ----------- |
 | GCP_SERVICES     | comma separated list of services to monitor, if not specified will monitor all the services, e.g. `gce_instance,cloud_function` |  |
@@ -27,3 +29,17 @@ Worker function execution can be tweaked with environment variables. In Google F
 | REQUIRE_VALID_CERTIFICATE | determines whether worker will verify SSL certificate of Dynatrace endpoint | True |
 | SERVICE_USAGE_BOOKING | `source` if API calls should use default billing mechanism, `destination` if they should be billed per project | `source` |
 | USE_PROXY | Depending on value of this flag, function will use proxy settings for either Dynatrace, GCP API or both. Allowed values: `ALL`, `DT_ONLY`, `GCP_ONLY` |  |
+
+### Log processing configuration variables
+
+| Variable name | description   | default value |
+| ----------------- | ------------- | ----------- |
+| DYNATRACE_ACCESS_KEY_SECRET_NAME | name of environment variable or Google Secret Manager Secret containing Dynatrace Access Key | DYNATRACE_ACCESS_KEY |
+| DYNATRACE_URL_SECRET_NAME | name of environment variable or Google Secret Manager Secret containing Dynatrace URL | DYNATRACE_URL |
+| GOOGLE_APPLICATION_CREDENTIALS | path to GCP service account key file | |
+| REQUIRE_VALID_CERTIFICATE | determines whether worker will verify SSL certificate of Dynatrace endpoint | True |
+| DYNATRACE_LOG_INGEST_CONTENT_MAX_LENGTH | determines max content length of log event. Should be the same or lower than on cluster | 8192 characters |
+| DYNATRACE_LOG_INGEST_EVENT_MAX_AGE_SECONDS | Determines max age of forwarded log event. Should be the same or lower than on cluster | 1 day |
+| LOGS_SUBSCRIPTION_PROJECT | GCP project of log sink pubsub subscription | |
+| SUBSCRIPTION_ID | subscription id of log sink pubsub subscription | |
+| DYNATRACE_LOG_INGEST_SENDING_WORKER_EXECUTION_PERIOD | Period of sending batched logs to Dynatrace | 60 seconds |

--- a/src/lib/context.py
+++ b/src/lib/context.py
@@ -15,14 +15,23 @@
 import enum
 import os
 from datetime import datetime, timedelta
+from queue import Queue
 from typing import Optional
 
 import aiohttp
 
 
+def get_int_environment_value(key: str, default_value: int) -> int:
+    environment_value = os.environ.get(key, None)
+    return int(environment_value) if environment_value and environment_value.isdigit() else default_value
+
+
 class LoggingContext:
     def __init__(self, scheduled_execution_id: Optional[str]):
         self.scheduled_execution_id: str = scheduled_execution_id[0:8] if scheduled_execution_id else None
+
+    def error(self, *args):
+        self.log("ERROR", *args)
 
     def log(self, *args):
         """
@@ -50,7 +59,45 @@ class LoggingContext:
         print(f"{timestamp_utc_iso} {context_section} : {message}")
 
 
-class Context(LoggingContext):
+class ExecutionContext(LoggingContext):
+    def __init__(
+            self,
+            project_id_owner: str,
+            dynatrace_api_key: str,
+            dynatrace_url: str,
+            scheduled_execution_id: Optional[str]
+    ):
+        super().__init__(scheduled_execution_id)
+        self.project_id_owner = project_id_owner
+        self.dynatrace_api_key = dynatrace_api_key
+        self.dynatrace_url = dynatrace_url
+        self.function_name = os.environ.get("FUNCTION_NAME", "Local")
+        self.location = os.environ.get("FUNCTION_REGION", "us-east1")
+        self.require_valid_certificate = os.environ.get("REQUIRE_VALID_CERTIFICATE", "True") in ["True", "T", "true"]
+
+
+class LogsContext(ExecutionContext):
+    def __init__(
+            self,
+            project_id_owner: str,
+            dynatrace_api_key: str,
+            dynatrace_url: str,
+            scheduled_execution_id: Optional[str],
+            job_queue: Queue
+    ):
+        super().__init__(
+            project_id_owner=project_id_owner,
+            dynatrace_api_key=dynatrace_api_key,
+            dynatrace_url=dynatrace_url,
+            scheduled_execution_id=scheduled_execution_id
+        )
+
+        self.job_queue = job_queue
+        self.request_body_max_size = get_int_environment_value("DYNATRACE_LOG_INGEST_REQUEST_MAX_SIZE", 1048576)
+        self.batch_max_messages = get_int_environment_value("DYNATRACE_LOG_INGEST_BATCH_MAX_MESSAGES", 10_000)
+
+
+class MetricsContext(ExecutionContext):
     def __init__(
             self,
             gcp_session: aiohttp.ClientSession,
@@ -64,22 +111,20 @@ class Context(LoggingContext):
             print_metric_ingest_input: bool,
             scheduled_execution_id: Optional[str]
     ):
-        super().__init__(scheduled_execution_id)
-
-        self.gcp_session = gcp_session
+        super().__init__(
+            project_id_owner=project_id_owner,
+            dynatrace_api_key=dynatrace_api_key,
+            dynatrace_url=dynatrace_url,
+            scheduled_execution_id=scheduled_execution_id
+        )
         self.dt_session = dt_session
-        self.project_id_owner = project_id_owner
+        self.gcp_session = gcp_session
         self.token = token
         self.execution_time = execution_time.replace(microsecond=0)
         self.execution_interval = timedelta(seconds=execution_interval_seconds)
-        self.dynatrace_api_key = dynatrace_api_key
-        self.dynatrace_url = dynatrace_url
         self.print_metric_ingest_input = print_metric_ingest_input
-        self.function_name = os.environ.get("FUNCTION_NAME", "Local")
-        self.location = os.environ.get("FUNCTION_REGION", "us-east1")
-        self.maximum_metric_data_points_per_minute = int(os.environ.get("MAXIMUM_METRIC_DATA_POINTS_PER_MINUTE", "100000"))
-        self.metric_ingest_batch_size = int(os.environ.get("METRIC_INGEST_BATCH_SIZE", "1000"))
-        self.require_valid_certificate = os.environ.get("REQUIRE_VALID_CERTIFICATE", "True") in ["True", "T", "true"]
+        self.maximum_metric_data_points_per_minute = get_int_environment_value("MAXIMUM_METRIC_DATA_POINTS_PER_MINUTE", 100000)
+        self.metric_ingest_batch_size = get_int_environment_value("METRIC_INGEST_BATCH_SIZE", 1000)
         self.use_x_goog_user_project_header = {project_id_owner: False}
 
         # self monitoring data

--- a/src/lib/credentials.py
+++ b/src/lib/credentials.py
@@ -20,7 +20,7 @@ import time
 import jwt
 from aiohttp import ClientSession
 
-from lib.context import LoggingContext, Context
+from lib.context import LoggingContext
 
 _METADATA_ROOT = "http://metadata.google.internal/computeMetadata/v1"
 _METADATA_FLAVOR_HEADER = "metadata-flavor"
@@ -37,6 +37,14 @@ async def fetch_dynatrace_api_key(gcp_session: ClientSession, project_id: str, t
 
 async def fetch_dynatrace_url(gcp_session: ClientSession, project_id: str, token: str, ):
     return await fetch_secret(gcp_session, project_id, token, _DYNATRACE_URL_SECRET_NAME)
+
+
+def get_dynatrace_api_key_from_env():
+    return os.environ.get(_DYNATRACE_ACCESS_KEY_SECRET_NAME, None)
+
+
+def get_dynatrace_url_from_env():
+    return os.environ.get(_DYNATRACE_URL_SECRET_NAME, None)
 
 
 async def fetch_secret(session: ClientSession, project_id: str, token: str, secret_name: str):

--- a/src/lib/entities/decorator.py
+++ b/src/lib/entities/decorator.py
@@ -17,7 +17,7 @@
 from functools import wraps
 from typing import Dict, Iterable, Text
 
-from lib.context import Context
+from lib.context import MetricsContext
 from lib.entities.model import Entity, ExtractEntitesFunc
 from lib.metrics import GCPService
 
@@ -35,7 +35,7 @@ def entity_extractor(service_type: Text):
 
     def register_extractor(fun: ExtractEntitesFunc) -> ExtractEntitesFunc:
         @wraps(fun)
-        async def get_and_upload(ctx: Context, project_id: str, svc_def: GCPService) -> Iterable[Entity]:
+        async def get_and_upload(ctx: MetricsContext, project_id: str, svc_def: GCPService) -> Iterable[Entity]:
             try:
                 entities = await fun(ctx, project_id, svc_def)
             except Exception as e:

--- a/src/lib/entities/extractors/cloud_function.py
+++ b/src/lib/entities/extractors/cloud_function.py
@@ -16,7 +16,7 @@ import re
 from functools import partial
 from typing import Any, Dict, Iterable, Text
 
-from lib.context import Context
+from lib.context import MetricsContext
 from lib.entities.decorator import entity_extractor
 from lib.entities.google_api import generic_paging
 from lib.entities.ids import get_func_create_entity_id, LabelToApiRspMapping
@@ -84,7 +84,7 @@ def _cloud_function_resp_to_monitored_entities(page: Dict[Text, Any], svc_def: G
 
 
 @entity_extractor("cloud_function")
-async def get_cloud_function_entity(ctx: Context, project_id: str, svc_def: GCPService) -> Iterable[Entity]:
+async def get_cloud_function_entity(ctx: MetricsContext, project_id: str, svc_def: GCPService) -> Iterable[Entity]:
     """ Retrieve entity info on GCP cloud functions from google api. """
     url = f"https://cloudfunctions.googleapis.com/v1/projects/{project_id}/locations/-/functions"
     mapper_func = partial(_cloud_function_resp_to_monitored_entities, svc_def=svc_def)

--- a/src/lib/entities/extractors/cloud_sql.py
+++ b/src/lib/entities/extractors/cloud_sql.py
@@ -15,7 +15,7 @@
 from functools import partial
 from typing import Any, Dict, Iterable, Text
 
-from lib.context import Context
+from lib.context import MetricsContext
 from lib.entities.decorator import entity_extractor
 from lib.entities.google_api import generic_paging
 from lib.entities.ids import get_func_create_entity_id, LabelToApiRspMapping
@@ -59,7 +59,7 @@ def _cloud_sql_resp_to_monitored_entities(page: Dict[Text, Any], svc_def: GCPSer
 
 
 @entity_extractor("cloudsql_database")
-async def get_cloud_sql_entity(ctx: Context, project_id: str, svc_def: GCPService) -> Iterable[Entity]:
+async def get_cloud_sql_entity(ctx: MetricsContext, project_id: str, svc_def: GCPService) -> Iterable[Entity]:
     """ Retrieve entity info on GCP Cloud SQL from google api. """
     url = f"https://sqladmin.googleapis.com/sql/v1beta4/projects/{project_id}/instances"
     mapper_func = partial(_cloud_sql_resp_to_monitored_entities, svc_def=svc_def)

--- a/src/lib/entities/extractors/filestore_instance.py
+++ b/src/lib/entities/extractors/filestore_instance.py
@@ -17,7 +17,7 @@ import re
 from functools import partial
 from typing import Any, Dict, Iterable, Text
 
-from lib.context import Context
+from lib.context import MetricsContext
 from lib.entities.decorator import entity_extractor
 from lib.entities.google_api import generic_paging
 from lib.entities.ids import get_func_create_entity_id, LabelToApiRspMapping
@@ -86,7 +86,7 @@ def _filestore_instance_resp_to_monitored_entities(page: Dict[Text, Any], svc_de
 
 
 @entity_extractor("filestore_instance")
-async def get_filestore_instance_entity(ctx: Context, project_id: str, svc_def: GCPService) -> Iterable[Entity]:
+async def get_filestore_instance_entity(ctx: MetricsContext, project_id: str, svc_def: GCPService) -> Iterable[Entity]:
     """ Retrieve entity info on GCP filestore instance from google api. """
     url = f"https://file.googleapis.com/v1/projects/{project_id}/locations/-/instances"
     mapper_func = partial(_filestore_instance_resp_to_monitored_entities, svc_def=svc_def)

--- a/src/lib/entities/extractors/gce_instance.py
+++ b/src/lib/entities/extractors/gce_instance.py
@@ -17,7 +17,7 @@ import re
 from functools import partial
 from typing import Any, Dict, Iterable, Text
 
-from lib.context import Context
+from lib.context import MetricsContext
 from lib.entities.decorator import entity_extractor
 from lib.entities.google_api import generic_paging, fetch_zones
 from lib.entities.ids import get_func_create_entity_id, LabelToApiRspMapping
@@ -109,7 +109,7 @@ def _cloud_function_resp_to_monitored_entities(page: Dict[Text, Any], svc_def: G
 
 
 @entity_extractor("gce_instance")
-async def get_cloud_function_entity(ctx: Context, project_id: str, svc_def: GCPService) -> Iterable[Entity]:
+async def get_cloud_function_entity(ctx: MetricsContext, project_id: str, svc_def: GCPService) -> Iterable[Entity]:
     """ Retrieve entity info on GCP cloud functions from google api. """
     zones = await fetch_zones(ctx, project_id)
 

--- a/src/lib/entities/extractors/pubsub_subscription.py
+++ b/src/lib/entities/extractors/pubsub_subscription.py
@@ -16,7 +16,7 @@ import re
 from functools import partial
 from typing import Any, Dict, Iterable, Text
 
-from lib.context import Context
+from lib.context import MetricsContext
 from lib.entities.decorator import entity_extractor
 from lib.entities.google_api import generic_paging
 from lib.entities.ids import get_func_create_entity_id, LabelToApiRspMapping
@@ -79,7 +79,7 @@ def _cloud_function_resp_to_monitored_entities(page: Dict[Text, Any], svc_def: G
 
 
 @entity_extractor("pubsub_subscription")
-async def get_cloud_function_entity(ctx: Context, project_id: str, svc_def: GCPService) -> Iterable[Entity]:
+async def get_cloud_function_entity(ctx: MetricsContext, project_id: str, svc_def: GCPService) -> Iterable[Entity]:
     """ Retrieve entity info on GCP cloud functions from google api. """
     url = f"https://pubsub.googleapis.com/v1/projects/{project_id}/subscriptions/"
     mapper_func = partial(_cloud_function_resp_to_monitored_entities, svc_def=svc_def)

--- a/src/lib/entities/google_api.py
+++ b/src/lib/entities/google_api.py
@@ -15,12 +15,12 @@
 
 from typing import Any, Callable, Dict, List, Text
 
-from lib.context import Context
+from lib.context import MetricsContext
 from lib.entities.model import Entity
 
 
 async def fetch_zones(
-        context: Context,
+        context: MetricsContext,
         project_id: str
 ) -> List[str]:
     headers = {
@@ -46,7 +46,7 @@ async def fetch_zones(
 
 async def generic_paging(
         url: Text,
-        ctx: Context,
+        ctx: MetricsContext,
         mapper: Callable[[Dict[Any, Any]], List[Entity]]
 ) -> List[Entity]:
     """Apply mapper function on any page returned by gcp api url."""

--- a/src/lib/entities/model.py
+++ b/src/lib/entities/model.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from json import dumps
 from typing import Callable, FrozenSet, Iterable, NamedTuple, Text
 
-from lib.context import Context
+from lib.context import MetricsContext
 from lib.metrics import GCPService
 
 
@@ -45,4 +45,4 @@ class Entity:  # pylint: disable=R0902
     dns_names: FrozenSet[str]
 
 
-ExtractEntitesFunc = Callable[[Context, str, GCPService], Iterable[Entity]]
+ExtractEntitesFunc = Callable[[MetricsContext, str, GCPService], Iterable[Entity]]

--- a/src/lib/logs/__init__.py
+++ b/src/lib/logs/__init__.py
@@ -1,0 +1,14 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+

--- a/src/lib/logs/dynatrace_client.py
+++ b/src/lib/logs/dynatrace_client.py
@@ -1,0 +1,130 @@
+#   Copyright 2021 Dynatrace LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import json
+import os
+import ssl
+import time
+import urllib
+from typing import List, Dict, Tuple
+from urllib.error import HTTPError
+from urllib.parse import urlparse
+from urllib.request import Request
+
+from lib.context import LogsContext
+
+should_verify_ssl_certificate = os.environ.get("REQUIRE_VALID_CERTIFICATE", "True") in ["True", "true"]
+ssl_context = ssl.create_default_context()
+if not should_verify_ssl_certificate:
+    ssl_context.check_hostname = False
+    ssl_context.verify_mode = ssl.CERT_NONE
+
+
+def send_logs(context: LogsContext, logs: List[Dict]):
+    # pylint: disable=R0912
+    start_time = time.time()
+    log_ingest_url = urlparse(context.dynatrace_url + "/api/v2/logs/ingest").geturl()
+    batches = prepare_serialized_batches(context, logs)
+
+    number_of_http_errors = 0
+    for batch in batches:
+        try:
+            encoded_body_bytes = batch.encode("UTF-8")
+            context.log('Log ingest payload size: {} kB'.format(round((len(encoded_body_bytes) / 1024), 3)))
+
+            status, reason, response = _perform_http_request(
+                method="POST",
+                url=log_ingest_url,
+                encoded_body_bytes=encoded_body_bytes,
+                headers={
+                    "Authorization": f"Api-Token {context.dynatrace_api_key}",
+                    "Content-Type": "application/json; charset=utf-8"
+                }
+            )
+            if status > 299:
+                context.error(f'Log ingest error: {status}, reason: {reason}, url: {log_ingest_url}, body: "{response}"')
+            else:
+                context.log("Log ingest payload pushed successfully")
+        except HTTPError as e:
+            raise e
+        except Exception as e:
+            context.error("Failed to ingest logs")
+            number_of_http_errors += 1
+            # all http requests failed and this is the last batch, raise this exception to trigger retry
+            if number_of_http_errors == len(batches):
+                raise e
+
+
+def _perform_http_request(
+        method: str,
+        url: str,
+        encoded_body_bytes: bytes,
+        headers: Dict
+) -> Tuple[int, str, str]:
+    req = Request(
+        url,
+        encoded_body_bytes,
+        headers,
+        method=method
+    )
+    try:
+        response = urllib.request.urlopen(req, context=ssl_context)
+        return response.code, response.reason, response.read().decode("utf-8")
+    except HTTPError as e:
+        response_body = e.read().decode("utf-8")
+        return e.code, e.reason, response_body
+
+
+# Heavily based on AWS log forwarder batching implementation
+def prepare_serialized_batches(context: LogsContext, logs: List[Dict]) -> List[str]:
+
+    log_entry_max_size = context.request_body_max_size - 2  # account for braces
+
+    batches: List[str] = []
+
+    logs_for_next_batch: List[str] = []
+    logs_for_next_batch_total_len = 0
+
+    for log_entry in logs:
+        brackets_len = 2
+        commas_len = len(logs_for_next_batch) - 1
+
+        new_batch_len = logs_for_next_batch_total_len + brackets_len + commas_len
+
+        next_entry_serialized = json.dumps(log_entry)
+
+        next_entry_size = len(next_entry_serialized.encode("UTF-8"))
+        if next_entry_size > log_entry_max_size:
+            # shouldn't happen as we are already truncating the content field, but just for safety
+            context.log(f"Dropping entry, as it's size is {next_entry_size}, bigger than max entry size: {log_entry_max_size}")
+
+        batch_length_if_added_entry = new_batch_len + 1 + len(next_entry_serialized)  # +1 is for comma
+
+        if batch_length_if_added_entry > context.request_body_max_size:
+            # would overflow limit, close batch and prepare new
+            batch = "[" + ",".join(logs_for_next_batch) + "]"
+            batches.append(batch)
+
+            logs_for_next_batch = []
+            logs_for_next_batch_total_len = 0
+
+        logs_for_next_batch.append(next_entry_serialized)
+        logs_for_next_batch_total_len += next_entry_size
+
+    if len(logs_for_next_batch) >= 1:
+        # finalize last batch
+        batch = "[" + ",".join(logs_for_next_batch) + "]"
+        batches.append(batch)
+
+    return batches

--- a/src/lib/logs/log_forwarder.py
+++ b/src/lib/logs/log_forwarder.py
@@ -30,7 +30,7 @@ SUBSCRIPTION_ID = os.environ.get('LOGS_SUBSCRIPTION_ID', None)
 
 
 MAX_MESSAGES_PROCESSED = 10_000
-MAX_WORKERS = 10_000
+MAX_WORKERS = 100
 
 
 def run_logs(logging_context: LoggingContext):

--- a/src/lib/logs/log_forwarder.py
+++ b/src/lib/logs/log_forwarder.py
@@ -1,0 +1,54 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+import os
+from concurrent.futures.thread import ThreadPoolExecutor
+from queue import Queue
+from threading import Thread
+
+from google.cloud import pubsub
+from google.cloud.pubsub_v1.subscriber.scheduler import ThreadScheduler
+from google.cloud.pubsub_v1.types import FlowControl
+
+from lib.context import get_int_environment_value, LoggingContext
+from lib.logs.logs_processor import create_process_message_handler
+from lib.logs.logs_sending_worker import create_log_sending_worker_loop
+
+PROJECT_ID = os.environ.get('LOGS_SUBSCRIPTION_PROJECT', None)
+SUBSCRIPTION_ID = os.environ.get('LOGS_SUBSCRIPTION_ID', None)
+EXECUTION_PERIOD_SECONDS = get_int_environment_value("DYNATRACE_LOG_INGEST_SENDING_WORKER_EXECUTION_PERIOD", 60)
+
+
+def run_logs(logging_context: LoggingContext):
+    if not PROJECT_ID or not SUBSCRIPTION_ID:
+        raise Exception("Cannot start pubsub streaming pull - LOGS_SUBSCRIPTION_PROJECT or LOGS_SUBSCRIPTION_ID are not defined")
+    # Settings for job queue size and subscriber should be fine tuned, but we have to do performance tests first
+    job_queue = Queue(10_000)
+    subscriber_client = pubsub.SubscriberClient()
+    subscription_path = subscriber_client.subscription_path(PROJECT_ID, SUBSCRIPTION_ID)
+    logging_context.log(f"Subscribing on '{subscription_path}'")
+    flow_control = FlowControl(max_messages=10_000)
+    subscriber = subscriber_client.subscribe(
+        subscription=subscription_path,
+        callback=create_process_message_handler(job_queue),
+        flow_control=flow_control,
+        scheduler=ThreadScheduler(ThreadPoolExecutor(
+            max_workers=100,
+            thread_name_prefix="PubSubSubscription"
+    )))
+    worker_loop = create_log_sending_worker_loop(EXECUTION_PERIOD_SECONDS, job_queue)
+    logs_sending_worker_thread = Thread(target=worker_loop, name="LogsSendingWorkerThread", daemon=True)
+    logs_sending_worker_thread.start()
+
+    subscriber.result()

--- a/src/lib/logs/log_forwarder.py
+++ b/src/lib/logs/log_forwarder.py
@@ -21,33 +21,36 @@ from google.cloud import pubsub
 from google.cloud.pubsub_v1.subscriber.scheduler import ThreadScheduler
 from google.cloud.pubsub_v1.types import FlowControl
 
-from lib.context import get_int_environment_value, LoggingContext
-from lib.logs.logs_processor import create_process_message_handler
+from lib.context import LoggingContext
+from lib.logs.logs_processor import create_process_message_handler, SENDING_WORKER_EXECUTION_PERIOD_SECONDS
 from lib.logs.logs_sending_worker import create_log_sending_worker_loop
 
 PROJECT_ID = os.environ.get('LOGS_SUBSCRIPTION_PROJECT', None)
 SUBSCRIPTION_ID = os.environ.get('LOGS_SUBSCRIPTION_ID', None)
-EXECUTION_PERIOD_SECONDS = get_int_environment_value("DYNATRACE_LOG_INGEST_SENDING_WORKER_EXECUTION_PERIOD", 60)
+
+
+MAX_MESSAGES_PROCESSED = 10_000
+MAX_WORKERS = 10_000
 
 
 def run_logs(logging_context: LoggingContext):
     if not PROJECT_ID or not SUBSCRIPTION_ID:
         raise Exception("Cannot start pubsub streaming pull - LOGS_SUBSCRIPTION_PROJECT or LOGS_SUBSCRIPTION_ID are not defined")
     # Settings for job queue size and subscriber should be fine tuned, but we have to do performance tests first
-    job_queue = Queue(10_000)
+    job_queue = Queue(MAX_MESSAGES_PROCESSED)
     subscriber_client = pubsub.SubscriberClient()
     subscription_path = subscriber_client.subscription_path(PROJECT_ID, SUBSCRIPTION_ID)
     logging_context.log(f"Subscribing on '{subscription_path}'")
-    flow_control = FlowControl(max_messages=10_000)
+    flow_control = FlowControl(max_messages=MAX_MESSAGES_PROCESSED)
     subscriber = subscriber_client.subscribe(
         subscription=subscription_path,
         callback=create_process_message_handler(job_queue),
         flow_control=flow_control,
         scheduler=ThreadScheduler(ThreadPoolExecutor(
-            max_workers=100,
+            max_workers=MAX_WORKERS,
             thread_name_prefix="PubSubSubscription"
     )))
-    worker_loop = create_log_sending_worker_loop(EXECUTION_PERIOD_SECONDS, job_queue)
+    worker_loop = create_log_sending_worker_loop(SENDING_WORKER_EXECUTION_PERIOD_SECONDS, job_queue)
     logs_sending_worker_thread = Thread(target=worker_loop, name="LogsSendingWorkerThread", daemon=True)
     logs_sending_worker_thread.start()
 

--- a/src/lib/logs/logs_processor.py
+++ b/src/lib/logs/logs_processor.py
@@ -1,0 +1,98 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+import json
+import queue
+import traceback
+from datetime import datetime, timedelta, timezone
+from functools import partial
+from typing import Optional, Dict, Callable
+from queue import Queue
+
+from dateutil.parser import *
+from google.cloud.pubsub_v1.subscriber.message import Message
+
+from lib.context import LoggingContext, get_int_environment_value
+
+_CONTENT_LENGTH_LIMIT = get_int_environment_value("DYNATRACE_LOG_INGEST_CONTENT_MAX_LENGTH", 8192)
+_EVENT_AGE_LIMIT_SECONDS = get_int_environment_value("DYNATRACE_LOG_INGEST_EVENT_MAX_AGE_SECONDS", int(timedelta(days=1).total_seconds()))
+
+
+class LogProcessingJob:
+    payload: Dict
+    message: Message
+
+    def __init__(self, payload: Dict, message: Message):
+        self.payload = payload
+        self.message = message
+
+
+def create_process_message_handler(log_jobs_queue: Queue) -> Callable[[Message], None]:
+    return partial(_process_message, log_jobs_queue)
+
+
+def _process_message(log_jobs_queue: Queue, message: Message):
+    context = LoggingContext(str(message.ack_id.__hash__())[-8:])
+    try:
+        _do_process_message(context, log_jobs_queue, message)
+    except Exception as exception:
+        if isinstance(exception, queue.Full):
+            context.error(f"Failed to process message due full job queue, rejecting the message")
+            message.nack()
+        else:
+            context.error(f"Failed to process message due to {type(exception).__name__}")
+            traceback.print_exc()
+
+
+def _do_process_message(context: LoggingContext, log_jobs_queue: Queue, message: Message):
+    data = message.data.decode("UTF-8")
+    # context.log(f"Data: {data}")
+
+    payload = _create_dt_log_payload(context, data)
+    # context.log(f"Payload: {payload}")
+
+    if not payload:
+        message.ack()
+    else:
+        job = LogProcessingJob(payload, message)
+        log_jobs_queue.put(job, True, 61)
+
+
+def _create_dt_log_payload(context: LoggingContext, message_data: str) -> Optional[Dict]:
+    event = json.loads(message_data)
+    payload = {}
+
+    timestamp = event['timestamp']
+    if 'timestamp' in event:
+        timestamp_datetime = parse(timestamp)
+        event_age_in_seconds = (datetime.now(timezone.utc) - timestamp_datetime).total_seconds()
+        if event_age_in_seconds > _EVENT_AGE_LIMIT_SECONDS:
+            context.log(f"Skipping message due to too old timestamp: {timestamp}")
+            return None
+
+    payload['timestamp'] = timestamp
+    payload['cloud.provider'] = 'gcp'
+    payload['content'] = message_data[:_CONTENT_LENGTH_LIMIT]
+    payload['severity'] = event.get("severity", None)
+
+    return payload
+
+
+def _adjust_log_content(content: str, max_len: Optional[int] = 8192, trailing_chars: Optional[str] = "...more"):
+    """
+    Truncate log content to the actual Dynatrace log content length limit
+    """
+    if max_len is not None and len(content) >= max_len:
+        return content[0:max_len - len(trailing_chars)] + trailing_chars if trailing_chars else content[0:max_len]
+    return content

--- a/src/lib/logs/logs_processor.py
+++ b/src/lib/logs/logs_processor.py
@@ -27,6 +27,7 @@ from lib.context import LoggingContext, get_int_environment_value
 
 _CONTENT_LENGTH_LIMIT = get_int_environment_value("DYNATRACE_LOG_INGEST_CONTENT_MAX_LENGTH", 8192)
 _EVENT_AGE_LIMIT_SECONDS = get_int_environment_value("DYNATRACE_LOG_INGEST_EVENT_MAX_AGE_SECONDS", int(timedelta(days=1).total_seconds()))
+SENDING_WORKER_EXECUTION_PERIOD_SECONDS = get_int_environment_value("DYNATRACE_LOG_INGEST_SENDING_WORKER_EXECUTION_PERIOD", 60)
 
 
 class LogProcessingJob:
@@ -66,7 +67,7 @@ def _do_process_message(context: LoggingContext, log_jobs_queue: Queue, message:
         message.ack()
     else:
         job = LogProcessingJob(payload, message)
-        log_jobs_queue.put(job, True, 61)
+        log_jobs_queue.put(job, True, SENDING_WORKER_EXECUTION_PERIOD_SECONDS + 1)
 
 
 def _create_dt_log_payload(context: LoggingContext, message_data: str) -> Optional[Dict]:

--- a/src/lib/logs/logs_sending_worker.py
+++ b/src/lib/logs/logs_sending_worker.py
@@ -1,0 +1,92 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import traceback
+from functools import partial
+from queue import Queue
+from time import sleep, time
+from typing import List, Callable
+
+from lib.context import LogsContext
+from lib.credentials import get_dynatrace_api_key_from_env, get_dynatrace_url_from_env, get_project_id_from_environment
+from lib.logs.dynatrace_client import send_logs
+from lib.logs.logs_processor import LogProcessingJob
+
+
+def create_log_sending_worker_loop(execution_period_seconds : int, job_queue: Queue) -> Callable:
+    return partial(_log_sending_worker_loop, execution_period_seconds, job_queue)
+
+
+def _create_logs_context(job_queue: Queue):
+    dynatrace_api_key = get_dynatrace_api_key_from_env()
+    dynatrace_url = get_dynatrace_url_from_env()
+    project_id_owner = get_project_id_from_environment()
+
+    return LogsContext(
+        project_id_owner=project_id_owner,
+        dynatrace_api_key=dynatrace_api_key,
+        dynatrace_url=dynatrace_url,
+        scheduled_execution_id=str(int(time()))[-8:],
+        job_queue=job_queue
+    )
+
+
+def _log_sending_worker_loop(execution_period_seconds : int, job_queue: Queue):
+    while True:
+        _loop_single_period(execution_period_seconds, job_queue)
+
+
+def _loop_single_period(execution_period_seconds: int, job_queue: Queue):
+    try:
+        context = _create_logs_context(job_queue)
+        _sleep_until_next_execution(execution_period_seconds)
+        _process_jobs(context)
+    except Exception:
+        print("Logs Sending Worker Loop Exception:")
+        traceback.print_exc()
+
+
+def _sleep_until_next_execution(execution_period_seconds):
+    if execution_period_seconds > 0:
+        execution_period_seconds = execution_period_seconds
+        current_timestamp = int(time())
+        next_execution_time = (int(current_timestamp / execution_period_seconds) + 1) * execution_period_seconds
+        sleep_time = next_execution_time - current_timestamp
+
+        if sleep_time > 0:
+            sleep(sleep_time)
+
+
+def _process_jobs(context: LogsContext):
+    context.log("Starting log sending worker execution")
+    jobs = _pull_jobs(context)
+    context.log(f"Processing {len(jobs)} messages")
+    payloads = [job.payload for job in jobs]
+    if payloads:
+        send_logs(context, payloads)
+        for job in jobs:
+            job.message.ack()
+            context.job_queue.task_done()
+    else:
+        context.log("Found no messages, skipping")
+    context.log(f"Finished Processing")
+
+
+def _pull_jobs(context):
+    jobs: List[LogProcessingJob] = []
+    # Limit for batch size to avoid pulling forever
+    while len(jobs) < context.batch_max_messages and context.job_queue.qsize() > 0:
+        job: LogProcessingJob = context.job_queue.get()
+        jobs.append(job)
+    return jobs
+

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -16,7 +16,7 @@ from datetime import timezone, datetime
 from http.client import InvalidURL
 from typing import Dict, List
 
-from lib.context import Context, DynatraceConnectivity
+from lib.context import MetricsContext, DynatraceConnectivity
 from lib.entities.ids import _create_mmh3_hash
 from lib.entities.model import Entity
 from lib.metrics import DISTRIBUTION_VALUE_KEY, Metric, TYPED_VALUE_KEY_MAPPING, GCPService, \
@@ -25,7 +25,7 @@ from lib.metrics import DISTRIBUTION_VALUE_KEY, Metric, TYPED_VALUE_KEY_MAPPING,
 UNIT_10TO2PERCENT = "10^2.%"
 
 
-async def push_ingest_lines(context: Context, project_id: str, fetch_metric_results: List[IngestLine]):
+async def push_ingest_lines(context: MetricsContext, project_id: str, fetch_metric_results: List[IngestLine]):
     if context.dynatrace_connectivity != DynatraceConnectivity.Ok:
         context.log(project_id, f"Skipping push due to detected connectivity error")
         return
@@ -63,7 +63,7 @@ async def push_ingest_lines(context: Context, project_id: str, fetch_metric_resu
         context.log(project_id, f"Finished uploading metric ingest lines to Dynatrace in {push_data_time} s")
 
 
-async def _push_to_dynatrace(context: Context, project_id: str, lines_batch: List[IngestLine]):
+async def _push_to_dynatrace(context: MetricsContext, project_id: str, lines_batch: List[IngestLine]):
     ingest_input = "\n".join([line.to_string() for line in lines_batch])
     if context.print_metric_ingest_input:
         context.log("Ingest input is: ")
@@ -100,7 +100,7 @@ async def _push_to_dynatrace(context: Context, project_id: str, lines_batch: Lis
     await log_invalid_lines(context, ingest_response_json, lines_batch)
 
 
-async def log_invalid_lines(context: Context, ingest_response_json: Dict, lines_batch: List[IngestLine]):
+async def log_invalid_lines(context: MetricsContext, ingest_response_json: Dict, lines_batch: List[IngestLine]):
     error = ingest_response_json.get("error", None)
     if error is None:
         return
@@ -115,7 +115,7 @@ async def log_invalid_lines(context: Context, ingest_response_json: Dict, lines_
 
 
 async def fetch_metric(
-        context: Context,
+        context: MetricsContext,
         project_id: str,
         service: GCPService,
         metric: Metric

--- a/src/lib/self_monitoring.py
+++ b/src/lib/self_monitoring.py
@@ -15,13 +15,13 @@ import asyncio
 import json
 from typing import Dict, List
 
-from lib.context import Context
+from lib.context import MetricsContext
 from lib.metric_descriptor import SELF_MONITORING_METRIC_PREFIX, SELF_MONITORING_METRIC_MAP, \
     SELF_MONITORING_CONNECTIVITY_METRIC_TYPE, SELF_MONITORING_INGEST_LINES_METRIC_TYPE, \
     SELF_MONITORING_REQUEST_COUNT_METRIC_TYPE, SELF_MONITORING_PHASE_EXECUTION_TIME_METRIC_TYPE
 
 
-def log_self_monitoring_data(context: Context):
+def log_self_monitoring_data(context: MetricsContext):
     context.log("SFM", f"GCP Monitoring API request count [per project]: {context.gcp_metric_request_count}")
     context.log("SFM", f"Dynatrace MINT API request count [per response code]: {context.dynatrace_request_count}")
     context.log("SFM", f"Dynatrace MINT accepted lines count [per project]: {context.dynatrace_ingest_lines_ok_count}")
@@ -32,7 +32,7 @@ def log_self_monitoring_data(context: Context):
     context.log("SFM", f"Push data to Dynatrace execution time [per project]: {context.push_to_dynatrace_execution_time}")
 
 
-async def push_self_monitoring_time_series(context: Context, is_retry: bool = False):
+async def push_self_monitoring_time_series(context: MetricsContext, is_retry: bool = False):
     log_self_monitoring_data(context)
     try:
         context.log(f"Pushing self monitoring time series to GCP Monitor...")
@@ -60,7 +60,7 @@ async def push_self_monitoring_time_series(context: Context, is_retry: bool = Fa
         context.log(f"Failed to push self monitoring time series, reason is {type(e).__name__} {e}")
 
 
-async def create_metric_descriptors_if_missing(context: Context):
+async def create_metric_descriptors_if_missing(context: MetricsContext):
     try:
         dynatrace_metrics_descriptors = await context.gcp_session.request(
             'GET',
@@ -83,7 +83,7 @@ async def create_metric_descriptors_if_missing(context: Context):
         context.log(f"Failed to create self monitoring metrics descriptors, reason is {type(e).__name__} {e}")
 
 
-async def replace_metric_descriptor_if_required(context: Context,
+async def replace_metric_descriptor_if_required(context: MetricsContext,
                                                 existing_metric_descriptor: Dict,
                                                 metric_descriptor: Dict,
                                                 metric_type: str):
@@ -94,7 +94,7 @@ async def replace_metric_descriptor_if_required(context: Context,
         await create_metric_descriptor(context, metric_descriptor, metric_type)
 
 
-async def delete_metric_descriptor(context: Context, metric_type: str):
+async def delete_metric_descriptor(context: MetricsContext, metric_type: str):
     context.log(f"Removing old descriptor for '{metric_type}'")
     response = await context.gcp_session.request(
         "DELETE",
@@ -106,7 +106,7 @@ async def delete_metric_descriptor(context: Context, metric_type: str):
         context.log(f"Failed to remove descriptor for '{metric_type}' due to '{response_body}'")
 
 
-async def create_metric_descriptor(context: Context, metric_descriptor: Dict, metric_type: str):
+async def create_metric_descriptor(context: MetricsContext, metric_descriptor: Dict, metric_type: str):
     context.log(f"Creating missing metric descriptor for '{metric_type}'")
     response = await context.gcp_session.request(
         "POST",
@@ -125,7 +125,7 @@ def extract_label_keys(metric_descriptor: Dict):
 
 
 def create_time_serie(
-        context: Context,
+        context: MetricsContext,
         metric_type: str,
         metric_labels: Dict,
         points: List[Dict],
@@ -151,7 +151,7 @@ def create_time_serie(
     }
 
 
-def create_self_monitoring_time_series(context: Context) -> Dict:
+def create_self_monitoring_time_series(context: MetricsContext) -> Dict:
     interval = {"endTime": context.execution_time.isoformat() + "Z"}
     time_series = [
         create_time_serie(

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ from typing import Dict, List, Optional
 import yaml
 
 from lib.clientsession_provider import init_dt_client_session, init_gcp_client_session
-from lib.context import Context, LoggingContext
+from lib.context import MetricsContext, LoggingContext
 from lib.credentials import create_token, get_project_id_from_environment, fetch_dynatrace_api_key, fetch_dynatrace_url, \
     get_all_accessible_projects
 from lib.entities import entities_extractors
@@ -105,7 +105,7 @@ async def handle_event(event: Dict, event_context, project_id_owner: Optional[st
         print_metric_ingest_input = \
             "PRINT_METRIC_INGEST_INPUT" in os.environ and os.environ["PRINT_METRIC_INGEST_INPUT"].upper() == "TRUE"
 
-        context = Context(
+        context = MetricsContext(
             gcp_session=gcp_session,
             dt_session=dt_session,
             project_id_owner=project_id_owner,
@@ -142,7 +142,7 @@ async def handle_event(event: Dict, event_context, project_id_owner: Optional[st
     # Noise on windows at the end of the logs is caused by https://github.com/aio-libs/aiohttp/issues/4324
 
 
-async def process_project_metrics(context: Context, project_id: str, services: List[GCPService]):
+async def process_project_metrics(context: MetricsContext, project_id: str, services: List[GCPService]):
     context.log(project_id, f"Starting processing...")
     await check_x_goog_user_project_header_permissions(context, project_id)
     ingest_lines = await fetch_ingest_lines_task(context, project_id, services)
@@ -152,14 +152,14 @@ async def process_project_metrics(context: Context, project_id: str, services: L
     await push_ingest_lines(context, project_id, ingest_lines)
 
 
-async def check_x_goog_user_project_header_permissions(context: Context, project_id: str):
+async def check_x_goog_user_project_header_permissions(context: MetricsContext, project_id: str):
     try:
         await _check_x_goog_user_project_header_permissions(context, project_id)
     except Exception as e:
         context.log(project_id, f"Unexpected exception when checking 'x-goog-user-project' header: {e}")
 
 
-async def _check_x_goog_user_project_header_permissions(context: Context, project_id: str):
+async def _check_x_goog_user_project_header_permissions(context: MetricsContext, project_id: str):
     if project_id in context.use_x_goog_user_project_header:
         return
 
@@ -189,7 +189,7 @@ async def _check_x_goog_user_project_header_permissions(context: Context, projec
         context.log(project_id, f"Unexpected response when checking 'x-goog-user-project' header: {str(page)}")
 
 
-async def fetch_ingest_lines_task(context: Context, project_id: str, services: List[GCPService]) -> List[IngestLine]:
+async def fetch_ingest_lines_task(context: MetricsContext, project_id: str, services: List[GCPService]) -> List[IngestLine]:
     fetch_metric_tasks = []
     topology_tasks = []
     topology_task_services = []
@@ -275,7 +275,7 @@ def extract_technology_name(config_yaml):
 
 
 async def run_fetch_metric(
-        context: Context,
+        context: MetricsContext,
         project_id: str,
         service: GCPService,
         metric: Metric

--- a/src/operation_mode.py
+++ b/src/operation_mode.py
@@ -1,0 +1,29 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import enum
+
+
+class OperationMode(enum.Enum):
+    Metrics = enum.auto(),
+    Logs = enum.auto()
+
+    @staticmethod
+    def from_environment_string(string: str):
+        if not string:
+            return None
+
+        try:
+            return OperationMode[string.casefold().capitalize()]
+        except Exception:
+            return None

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,3 +3,5 @@ aiodns==2.0.0
 mmh3==2.5.1
 PyJWT==1.7.1
 PyYAML==5.4
+google-cloud-pubsub==2.4.0
+python-dateutil==2.8.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,14 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,0 +1,154 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import json
+import time
+from queue import Queue
+from typing import NewType, Any
+
+import pytest
+from google.cloud.pubsub_v1.subscriber._protocol.requests import AckRequest
+from google.cloud.pubsub_v1.subscriber.message import Message
+from google.protobuf.timestamp_pb2 import Timestamp
+from google.pubsub_v1 import PubsubMessage
+from wiremock.constants import Config
+from wiremock.resources.mappings import MappingRequest, HttpMethods, MappingResponse, Mapping
+from wiremock.resources.mappings.resource import Mappings
+from wiremock.resources.requests.resource import Requests
+from wiremock.server import WireMockServer
+
+from lib.logs.logs_processor import create_process_message_handler
+from lib.logs.logs_sending_worker import _loop_single_period
+
+LOG_MESSAGE_DATA = '{"insertId":"000000-ff1a5bfd-b64a-442e-91b2-deba5557dbfe","labels":{"execution_id":"zh2htc8ax7y6"},"logName":"projects/dynatrace-gcp-extension/logs/cloudfunctions.googleapis.com%2Fcloud-functions","receiveTimestamp":"2021-03-29T10:25:15.862698697Z","resource":{"labels":{"function_name":"dynatrace-gcp-function","project_id":"dynatrace-gcp-extension","region":"us-central1"},"type":"cloud_function"},"severity":"INFO","textPayload":"2021-03-29 10:25:11.101768  : Access to following projects: dynatrace-gcp-extension","timestamp":"2021-03-29T10:25:11.101Z","trace":"projects/dynatrace-gcp-extension/traces/f748c1e106a134178afee611c90bf984"}'
+
+MOCKED_API_PORT = 9011
+ACCESS_KEY = 'abcdefjhij1234567890'
+
+MonkeyPatchFixture = NewType("MonkeyPatchFixture", Any)
+system_variables = {
+    # 'DYNATRACE_LOG_INGEST_CONTENT_MAX_LENGTH': str(500),
+    'DYNATRACE_LOG_INGEST_REQUEST_MAX_SIZE': str(5 * 1024),
+    'DYNATRACE_URL': 'http://localhost:' + str(MOCKED_API_PORT),
+    'DYNATRACE_ACCESS_KEY': ACCESS_KEY,
+    'REQUIRE_VALID_CERTIFICATE': 'False'
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_wiremock():
+    # setup WireMock server
+    wiremock = WireMockServer(port=MOCKED_API_PORT)
+    wiremock.start()
+    Config.base_url = 'http://localhost:{}/__admin'.format(MOCKED_API_PORT)
+
+    # run test
+    yield
+
+    # stop WireMock server
+    wiremock.stop()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def cleanup():
+    Mappings.delete_all_mappings()
+    Requests.reset_request_journal()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup_env(monkeypatch):
+    for variable_name in system_variables:
+        monkeypatch.setenv(variable_name, system_variables[variable_name])
+
+
+def response(status: int, status_message: str):
+    Mappings.create_mapping(mapping=Mapping(
+        priority=100,
+        request=MappingRequest(
+            method=HttpMethods.POST,
+            url='/api/v2/logs/ingest',
+            headers={'Authorization': {'equalTo': "Api-Token {}".format(ACCESS_KEY)}},
+        ),
+        response=MappingResponse(
+            status=status,
+            status_message=status_message
+        ),
+        persistent=False
+    ))
+
+
+def test_execution_successful():
+    expected_cluster_response_code = 200
+
+    response(expected_cluster_response_code, "Success")
+
+    ack_queue = Queue()
+    job_queue = Queue()
+
+    message_handler = create_process_message_handler(job_queue)
+
+    expected_ack_ids = [f"ACK_ID_{i}" for i in range(0, 10)]
+
+    for ack_id in expected_ack_ids:
+        message = create_fake_message(ack_queue, ack_id=ack_id)
+        message_handler(message)
+
+    _loop_single_period(0, job_queue)
+    job_queue.join()
+
+    assert ack_queue.qsize() == len(expected_ack_ids)
+    while ack_queue.qsize() > 0:
+        request = ack_queue.get_nowait()
+        assert isinstance(request, AckRequest)
+        assert request.ack_id in expected_ack_ids
+        expected_ack_ids.remove(request.ack_id)
+
+    verify_requests(expected_cluster_response_code)
+
+
+def verify_requests(expected_cluster_response_code):
+    sent_requests = Requests.get_all_received_requests().get_json_data()
+    for request in sent_requests.get('requests'):
+        assert_correct_body_structure(request)
+        assert request.get('responseDefinition').get('status') == expected_cluster_response_code
+
+
+def assert_correct_body_structure(request):
+    request_body = request.get("request", {}).get("body", None)
+    assert request_body
+    request_data = json.loads(request_body)
+
+    for record in request_data:
+        assert 'cloud.provider' in record
+        assert record.get("cloud.provider") == "gcp"
+        assert 'content' in record
+        assert 'timestamp' in record
+
+
+def create_fake_message(
+        ack_queue,
+        ack_id="ACK_ID",
+        message_id="MESSAGE_ID",
+        message_data=LOG_MESSAGE_DATA,
+        timestamp_epoch_seconds=int(time.time())
+):
+    publish_time_timestamp = Timestamp()
+    publish_time_timestamp.seconds = timestamp_epoch_seconds
+
+    pubsub_message = PubsubMessage()
+    pubsub_message.data = message_data.encode("UTF-8")
+    pubsub_message.message_id = message_id
+    pubsub_message.publish_time = publish_time_timestamp
+    pubsub_message.ordering_key = ""
+
+    return Message(PubsubMessage.pb(pubsub_message), ack_id, 0, ack_queue)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+pytest==6.2.2
+wiremock==2.1.3


### PR DESCRIPTION
Initial POC of log forwarder in container. `dynatrace_client` has been copied from Azure log forwarder solution. Job queue and Pub/sub subscriber parameters have been selected arbitrarily, we need to run performance tests to fine tune them. Default behavior of `run_docker` scripts has been preserved.

I've introduced simple integration test with wiremock, as it happened to be simpler than messing with mocks. New stage has been added to `.travis.yml` to run the tests.