### PR TITLE
APM-293893: Implement FastCheck for Logs

### DIFF
--- a/src/lib/context.py
+++ b/src/lib/context.py
@@ -26,6 +26,10 @@ def get_int_environment_value(key: str, default_value: int) -> int:
     return int(environment_value) if environment_value and environment_value.isdigit() else default_value
 
 
+def get_should_require_valid_certificate() -> bool:
+    return os.environ.get("REQUIRE_VALID_CERTIFICATE", "True") in ["True", "T", "true"]
+
+
 class LoggingContext:
     def __init__(self, scheduled_execution_id: Optional[str]):
         self.scheduled_execution_id: str = scheduled_execution_id[0:8] if scheduled_execution_id else None
@@ -73,7 +77,7 @@ class ExecutionContext(LoggingContext):
         self.dynatrace_url = dynatrace_url
         self.function_name = os.environ.get("FUNCTION_NAME", "Local")
         self.location = os.environ.get("FUNCTION_REGION", "us-east1")
-        self.require_valid_certificate = os.environ.get("REQUIRE_VALID_CERTIFICATE", "True") in ["True", "T", "true"]
+        self.require_valid_certificate = get_should_require_valid_certificate()
 
 
 class LogsContext(ExecutionContext):

--- a/src/lib/fast_check.py
+++ b/src/lib/fast_check.py
@@ -1,6 +1,9 @@
 import asyncio
 import os
 import re
+import time
+from datetime import datetime
+from queue import Queue
 from typing import NamedTuple, List, Optional
 
 from urllib.parse import urljoin
@@ -9,10 +12,13 @@ from aiohttp import ClientSession
 from lib.context import LoggingContext
 from lib.credentials import get_all_accessible_projects, fetch_dynatrace_url, fetch_dynatrace_api_key, \
     get_project_id_from_environment
+from lib.instance_metadata import InstanceMetadata
+from lib.logs.dynatrace_client import send_logs
+from lib.logs.logs_sending_worker import create_logs_context
 
 service_name_pattern = re.compile(r"^projects\/([\w,-]*)\/services\/([\w,-.]*)$")
 
-CONFIGURATION_FLAGS = [
+METRICS_CONFIGURATION_FLAGS = [
     "PRINT_METRIC_INGEST_INPUT",
     "GOOGLE_APPLICATION_CREDENTIALS",
     "MAXIMUM_METRIC_DATA_POINTS_PER_MINUTE",
@@ -22,14 +28,23 @@ CONFIGURATION_FLAGS = [
     "USE_PROXY"
 ]
 
+LOGS_CONFIGURATION_FLAGS = [
+    "REQUIRE_VALID_CERTIFICATE",
+    "DYNATRACE_LOG_INGEST_CONTENT_MAX_LENGTH",
+    "DYNATRACE_LOG_INGEST_EVENT_MAX_AGE_SECONDS",
+    "LOGS_SUBSCRIPTION_PROJECT",
+    "LOGS_SUBSCRIPTION_ID",
+    "DYNATRACE_LOG_INGEST_SENDING_WORKER_EXECUTION_PERIOD",
+]
+
 GCP_SERVICE_USAGE_URL = 'https://serviceusage.googleapis.com/v1/projects/'
 
-required_services = [
+REQUIRED_SERVICES = [
     'monitoring.googleapis.com',
     'cloudresourcemanager.googleapis.com'
 ]
 
-dynatrace_required_token_scopes = [
+DYNATRACE_REQUIRED_TOKEN_SCOPES = [
     'metrics.ingest',
 ]
 
@@ -43,8 +58,7 @@ def find_service_name(service):
 def valid_dynatrace_scopes(token_metadata: dict):
     """Check whether Dynatrace token metadata has required scopes to start ingest metrics"""
     token_scopes = token_metadata.get('scopes', [])
-    return all(scope in token_scopes for scope in dynatrace_required_token_scopes) if token_scopes else False
-
+    return all(scope in token_scopes for scope in DYNATRACE_REQUIRED_TOKEN_SCOPES) if token_scopes else False
 
 
 async def get_dynatrace_token_metadata(dt_session: ClientSession, context: LoggingContext, dynatrace_url: str, dynatrace_api_key: str, timeout: Optional[int] = 2) -> dict:
@@ -69,7 +83,7 @@ async def get_dynatrace_token_metadata(dt_session: ClientSession, context: Loggi
         return {}
 
 
-class FastCheck:
+class MetricsFastCheck:
 
     def __init__(self, gcp_session: ClientSession, dt_session: ClientSession, token: str, logging_context: LoggingContext):
         self.gcp_session = gcp_session
@@ -100,9 +114,9 @@ class FastCheck:
     async def _check_services(self, project_id):
         list_services_result = await self.list_services(project_id)
         service_names = [find_service_name(service['name']) for service in list_services_result.get('services', [])]
-        if not all(name in service_names for name in required_services):
+        if not all(name in service_names for name in REQUIRED_SERVICES):
             self.logging_context.log(f'Cannot monitor project: \'{project_id}\'. '
-                                     f'Enable required services: {required_services}')
+                                     f'Enable required services: {REQUIRED_SERVICES}')
             return None
         return service_names
 
@@ -118,7 +132,7 @@ class FastCheck:
             token_metadata = await get_dynatrace_token_metadata(self.dt_session, self.logging_context, dynatrace_url, dynatrace_access_key)
             if token_metadata.get('revoked', None) or not valid_dynatrace_scopes(token_metadata):
                 self.logging_context.log(f'Dynatrace API Token for project: \'{project_id}\'is not valid. '
-                                         f'Check expiration time and required token scopes: {dynatrace_required_token_scopes}')
+                                         f'Check expiration time and required token scopes: {DYNATRACE_REQUIRED_TOKEN_SCOPES}')
                 return None
         except Exception as e:
             self.logging_context.log(f'Unable to get Dynatrace Secrets for project: {project_id}. Error details: {e}')
@@ -126,9 +140,9 @@ class FastCheck:
 
         return dynatrace_url, token_metadata
 
-    async def _init_(self) -> FastCheckResult:
-        self._check_configuration_flags()
-        self._check_version()
+    async def execute(self) -> FastCheckResult:
+        _check_configuration_flags(self.logging_context, METRICS_CONFIGURATION_FLAGS)
+        _check_version(self.logging_context)
 
         project_list = await get_all_accessible_projects(self.logging_context, self.gcp_session, self.token)
 
@@ -145,23 +159,40 @@ class FastCheck:
 
         return FastCheckResult(projects=ready_to_monitor)
 
-    def _check_configuration_flags(self):
-        configuration_flag_values = []
-        for key in CONFIGURATION_FLAGS:
-            value = os.environ.get(key, None)
-            if value is None:
-                configuration_flag_values.append(f"{key} is None")
-            else:
-                configuration_flag_values.append(f"{key} = '{value}'")
-        self.logging_context.log(f"Found configuration flags: {', '.join(configuration_flag_values)}")
-    
-    def _check_version(self):        
-        script_directory = os.path.dirname(os.path.realpath(__file__))
-        version_file_path = os.path.join(script_directory, "./../version.txt")
-        with open(version_file_path) as version_file:
-            _version = version_file.readline()
-            self.logging_context.log(f"Found version: {_version}")
+
+class LogsFastCheck:
+    def __init__(self, logging_context: LoggingContext, instance_metadata: InstanceMetadata):
+        self.instance_metadata = instance_metadata
+        self.logging_context = logging_context
+
+    def execute(self):
+        _check_configuration_flags(self.logging_context, LOGS_CONFIGURATION_FLAGS)
+        _check_version(self.logging_context)
+        self.logging_context.log("Sending the startup message")
+        container_name = self.instance_metadata.container_name if self.instance_metadata else "local deployment"
+        fast_check_event = {
+            'timestamp': datetime.utcnow().isoformat(" "),
+            'cloud.provider': 'gcp',
+            'content': f'GCP Log Forwarder has started at {container_name}',
+            'severity': 'INFO'
+        }
+        send_logs(create_logs_context(Queue()), [fast_check_event])
 
 
-    def __await__(self):
-        return self._init_().__await__()
+def _check_configuration_flags(logging_context: LoggingContext, flags_to_check: List[str]):
+    configuration_flag_values = []
+    for key in flags_to_check:
+        value = os.environ.get(key, None)
+        if value is None:
+            configuration_flag_values.append(f"{key} is None")
+        else:
+            configuration_flag_values.append(f"{key} = '{value}'")
+    logging_context.log(f"Found configuration flags: {', '.join(configuration_flag_values)}")
+
+
+def _check_version(logging_context: LoggingContext):
+    script_directory = os.path.dirname(os.path.realpath(__file__))
+    version_file_path = os.path.join(script_directory, "./../version.txt")
+    with open(version_file_path) as version_file:
+        _version = version_file.readline()
+        logging_context.log(f"Found version: {_version}")

--- a/src/lib/fast_check.py
+++ b/src/lib/fast_check.py
@@ -169,7 +169,7 @@ class LogsFastCheck:
         _check_configuration_flags(self.logging_context, LOGS_CONFIGURATION_FLAGS)
         _check_version(self.logging_context)
         self.logging_context.log("Sending the startup message")
-        container_name = self.instance_metadata.container_name if self.instance_metadata else "local deployment"
+        container_name = self.instance_metadata.hostname if self.instance_metadata else "local deployment"
         fast_check_event = {
             'timestamp': datetime.utcnow().isoformat(" "),
             'cloud.provider': 'gcp',

--- a/src/lib/instance_metadata.py
+++ b/src/lib/instance_metadata.py
@@ -81,6 +81,7 @@ class InstanceMetadataCheck:
                     audience=audience
                 )
                 self.logging_context.log(f'GCP instance metadata: {metadata}')
+                return metadata
             return None
 
     def _gcp_deployment(self):

--- a/src/lib/instance_metadata.py
+++ b/src/lib/instance_metadata.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import socket
 from collections import namedtuple
 from typing import Optional
@@ -16,7 +17,8 @@ InstanceMetadata = namedtuple('InstanceMetadata', [
     'container_name',
     'token_scopes',
     'service_account',
-    'audience'
+    'audience',
+    'hostname'
 ])
 
 
@@ -78,7 +80,8 @@ class InstanceMetadataCheck:
                     container_name=results[1],
                     token_scopes=results[2],
                     service_account=results[3],
-                    audience=audience
+                    audience=audience,
+                    hostname=os.environ.get("HOSTNAME", "")
                 )
                 self.logging_context.log(f'GCP instance metadata: {metadata}')
                 return metadata

--- a/src/lib/instance_metadata.py
+++ b/src/lib/instance_metadata.py
@@ -11,7 +11,7 @@ from lib.context import LoggingContext
 
 METADATA_URL = f'http://metadata.google.internal/computeMetadata/v1/'
 
-instance_metadata = namedtuple('instance_metadata', [
+InstanceMetadata = namedtuple('InstanceMetadata', [
     'project_id',
     'container_name',
     'token_scopes',
@@ -20,7 +20,7 @@ instance_metadata = namedtuple('instance_metadata', [
 ])
 
 
-class InstanceMetadata:
+class InstanceMetadataCheck:
 
     def __init__(self, gcp_session: ClientSession(), token: [str], logging_context: LoggingContext):
         self.gcp_session = gcp_session
@@ -59,7 +59,7 @@ class InstanceMetadata:
     async def audience(self):
         return await self._get_metadata('instance/service-accounts/default/identity?audience=https://accounts.google.com')
 
-    async def _init_(self) -> Optional[instance_metadata]:
+    async def execute(self) -> Optional[InstanceMetadata]:
         if self._gcp_deployment():
             metadata = [
                 self.project_id(),
@@ -73,13 +73,14 @@ class InstanceMetadata:
 
             if not all(result is None for result in results):
                 audience = jwt.decode(results[4], verify=False) if results[4] else ''
-                return instance_metadata(
+                metadata = InstanceMetadata(
                     project_id=results[0],
                     container_name=results[1],
                     token_scopes=results[2],
                     service_account=results[3],
                     audience=audience
                 )
+                self.logging_context.log(f'GCP instance metadata: {metadata}')
             return None
 
     def _gcp_deployment(self):
@@ -90,6 +91,3 @@ class InstanceMetadata:
         except Exception as e:
             self.logging_context.log(f'Local deployment detected. Skipped instance metadata info, the reason is: {e}')
             return False
-
-    def __await__(self):
-        return self._init_().__await__()

--- a/src/lib/logs/dynatrace_client.py
+++ b/src/lib/logs/dynatrace_client.py
@@ -22,11 +22,10 @@ from urllib.error import HTTPError
 from urllib.parse import urlparse
 from urllib.request import Request
 
-from lib.context import LogsContext
+from lib.context import LogsContext, get_should_require_valid_certificate
 
-should_verify_ssl_certificate = os.environ.get("REQUIRE_VALID_CERTIFICATE", "True") in ["True", "true"]
 ssl_context = ssl.create_default_context()
-if not should_verify_ssl_certificate:
+if not get_should_require_valid_certificate():
     ssl_context.check_hostname = False
     ssl_context.verify_mode = ssl.CERT_NONE
 
@@ -54,6 +53,7 @@ def send_logs(context: LogsContext, logs: List[Dict]):
             )
             if status > 299:
                 context.error(f'Log ingest error: {status}, reason: {reason}, url: {log_ingest_url}, body: "{response}"')
+                number_of_http_errors += 1
             else:
                 context.log("Log ingest payload pushed successfully")
         except HTTPError as e:

--- a/src/lib/logs/log_forwarder.py
+++ b/src/lib/logs/log_forwarder.py
@@ -54,4 +54,8 @@ def run_logs(logging_context: LoggingContext):
     logs_sending_worker_thread = Thread(target=worker_loop, name="LogsSendingWorkerThread", daemon=True)
     logs_sending_worker_thread.start()
 
-    subscriber.result()
+    try:
+        subscriber.result()
+    except Exception as subscription_exception:
+        logging_context.error(f"Pub/sub subscriber crashed for path {subscription_path}")
+        raise subscription_exception

--- a/src/lib/logs/logs_sending_worker.py
+++ b/src/lib/logs/logs_sending_worker.py
@@ -27,7 +27,7 @@ def create_log_sending_worker_loop(execution_period_seconds : int, job_queue: Qu
     return partial(_log_sending_worker_loop, execution_period_seconds, job_queue)
 
 
-def _create_logs_context(job_queue: Queue):
+def create_logs_context(job_queue: Queue):
     dynatrace_api_key = get_dynatrace_api_key_from_env()
     dynatrace_url = get_dynatrace_url_from_env()
     project_id_owner = get_project_id_from_environment()
@@ -48,7 +48,7 @@ def _log_sending_worker_loop(execution_period_seconds : int, job_queue: Queue):
 
 def _loop_single_period(execution_period_seconds: int, job_queue: Queue):
     try:
-        context = _create_logs_context(job_queue)
+        context = create_logs_context(job_queue)
         _sleep_until_next_execution(execution_period_seconds)
         _process_jobs(context)
     except Exception:

--- a/src/run_docker.py
+++ b/src/run_docker.py
@@ -22,8 +22,8 @@ from lib.clientsession_provider import init_dt_client_session, init_gcp_client_s
 from lib.configure_dynatrace import ConfigureDynatrace
 from lib.context import LoggingContext, get_int_environment_value
 from lib.credentials import create_token
-from lib.fast_check import FastCheck
-from lib.instance_metadata import InstanceMetadata
+from lib.fast_check import MetricsFastCheck, FastCheckResult, LogsFastCheck
+from lib.instance_metadata import InstanceMetadataCheck, InstanceMetadata
 from lib.logs.log_forwarder import run_logs
 from main import async_dynatrace_gcp_extension
 from operation_mode import OperationMode
@@ -40,23 +40,36 @@ async def scheduling_loop(project_ids: Optional[List[str]] = None):
         await asyncio.sleep(60)
 
 
-async def initial_check():
+async def metrics_initial_check() -> Optional[FastCheckResult]:
     async with init_gcp_client_session() as gcp_session, init_dt_client_session() as dt_session:
         token = await create_token(logging_context, gcp_session)
         if token:
-            fast_check_result = await FastCheck(gcp_session=gcp_session, dt_session=dt_session, token=token, logging_context=logging_context)
+            fast_check_result = await MetricsFastCheck(
+                gcp_session=gcp_session,
+                dt_session=dt_session,
+                token=token,
+                logging_context=logging_context
+            ).execute()
             if fast_check_result.projects:
                 logging_context.log(f'Monitoring enabled for the following projects: {fast_check_result}')
-                instance_metadata = await InstanceMetadata(gcp_session, token, logging_context)
-                if instance_metadata:
-                    logging_context.log(f'GCP: {instance_metadata}')
-                loop.create_task(scheduling_loop(fast_check_result.projects))
+                return fast_check_result
             else:
                 logging_context.log("Monitoring disabled. Check your project(s) settings.")
         else:
             logging_context.log(f'Monitoring disabled. Unable to acquire authorization token.')
-    await gcp_session.close()
-    await dt_session.close()
+
+        return None
+
+
+async def run_instance_metadata_check() -> Optional[InstanceMetadata]:
+    async with init_gcp_client_session() as gcp_session:
+        token = await create_token(logging_context, gcp_session)
+        if token:
+            return await InstanceMetadataCheck(gcp_session, token, logging_context).execute()
+        else:
+            logging_context.log(f'Instance metadata check skipped. Unable to acquire authorization token.')
+
+    return None
 
 
 async def try_configure_dynatrace():
@@ -73,15 +86,17 @@ def run_metrics():
         services = os.environ.get("GCP_SERVICES", "")
         logging_context.log(f"Running with configured services: {services}")
     loop.run_until_complete(try_configure_dynatrace())
-    loop.run_until_complete(initial_check())
-
-    run_loop_forever()
+    fast_check_result = loop.run_until_complete(metrics_initial_check())
+    if fast_check_result:
+        loop.create_task(scheduling_loop(fast_check_result.projects))
+        run_loop_forever()
 
 
 def run_loop_forever():
     try:
         loop.run_forever()
     finally:
+        print("Closing AsyncIO loop...")
         loop.run_until_complete(app.shutdown())
         loop.run_until_complete(runner.cleanup())
         loop.run_until_complete(app.cleanup())
@@ -127,6 +142,8 @@ loop.run_until_complete(runner.setup())
 site = web.TCPSite(runner, '0.0.0.0', HEALTH_CHECK_PORT)
 loop.run_until_complete(site.start())
 
+instance_metadata = loop.run_until_complete(run_instance_metadata_check())
+
 logging_context.log(f"Operation mode: {OPERATION_MODE.name}")
 
 if OPERATION_MODE == OperationMode.Metrics:
@@ -134,4 +151,5 @@ if OPERATION_MODE == OperationMode.Metrics:
 
 elif OPERATION_MODE == OperationMode.Logs:
     threading.Thread(target=run_loop_forever, name="AioHttpLoopWaiterThread", daemon=True).start()
+    LogsFastCheck(logging_context, instance_metadata).execute()
     run_logs(logging_context)


### PR DESCRIPTION
Introduced `LogsFastCheck` which prints out version and configuration flags for logs forwarder. Additionally it sends startup message to configured log ingest endpoint - which is verification of configuration and acts as a diagnostic information.
Additional changes:
- fix for outdated timestamps in integration test - test was passing but all messages were stashed due to too old timestamp
- Preserve asyncio loop in daemon thread to keep aiohttp working for logs forwarding