### PR TITLE
Initial Metadata extraction for GCP Logs Forwarder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
         packages:
           - default-jre
     script:
+      - PYTHONPATH="./src" pytest tests/unit -v
       - PYTHONPATH="./src" pytest tests/integration -v
   - stage: docker-build
     name: Docker build

--- a/HACKING.md
+++ b/HACKING.md
@@ -45,3 +45,4 @@ Worker function execution can be tweaked with environment variables. In Google F
 | LOGS_SUBSCRIPTION_PROJECT | GCP project of log sink pubsub subscription | |
 | LOGS_SUBSCRIPTION_ID | subscription id of log sink pubsub subscription | |
 | DYNATRACE_LOG_INGEST_SENDING_WORKER_EXECUTION_PERIOD | Period of sending batched logs to Dynatrace | 60 seconds |
+| DYNATRACE_TIMEOUT_SECONDS | Timeout of request to Dynatrace Log Ingest | 30 seconds |

--- a/src/config_logs/cloud_function.json
+++ b/src/config_logs/cloud_function.json
@@ -18,6 +18,10 @@
         {
           "key": "content",
           "pattern": "textPayload"
+        },
+        {
+          "key": "gcp.instance.name",
+          "pattern": "resource.labels.function_name"
         }
       ]
     }

--- a/src/config_logs/cloud_function.json
+++ b/src/config_logs/cloud_function.json
@@ -1,0 +1,25 @@
+{
+  "name": "cloud_function",
+  "displayName": "Cloud Function",
+  "rules": [
+    {
+      "sources": [
+        {
+          "sourceType": "logs",
+          "source": "resourceType",
+          "condition": "$eq('cloud_function')"
+        }
+      ],
+      "attributes": [
+        {
+          "key": "faas.id",
+          "pattern": "labels.execution_id"
+        },
+        {
+          "key": "content",
+          "pattern": "textPayload"
+        }
+      ]
+    }
+  ]
+}

--- a/src/config_logs/common.json
+++ b/src/config_logs/common.json
@@ -1,0 +1,51 @@
+{
+  "name": "common",
+  "displayName": "Common",
+  "rules": [
+    {
+      "sources": [],
+      "attributes": [
+        {
+          "key": "severity",
+          "pattern": "severity"
+        },
+        {
+          "key": "cloud.provider",
+          "pattern": "`gcp`"
+        },
+        {
+          "key": "cloud.region",
+          "pattern": "resource.labels.region || resource.labels.location"
+        },
+        {
+          "key": "gcp.region",
+          "pattern": "resource.labels.region || resource.labels.location"
+        },
+        {
+          "key": "gcp.project.id",
+          "pattern": "resource.labels.project_id"
+        },
+        {
+          "key": "gcp.instance.id",
+          "pattern": "resource.labels.instance_id"
+        },
+        {
+          "key": "gcp.instance.name",
+          "pattern": "resource.labels.function_name"
+        },
+        {
+          "key": "gcp.resource.type",
+          "pattern": "resource.type"
+        },
+        {
+          "key": "timestamp",
+          "pattern": "timestamp"
+        },
+        {
+          "key": "dt.logpath",
+          "pattern": "logName"
+        }
+      ]
+    }
+  ]
+}

--- a/src/config_logs/common.json
+++ b/src/config_logs/common.json
@@ -30,10 +30,6 @@
           "pattern": "resource.labels.instance_id"
         },
         {
-          "key": "gcp.instance.name",
-          "pattern": "resource.labels.function_name"
-        },
-        {
           "key": "gcp.resource.type",
           "pattern": "resource.type"
         },

--- a/src/config_logs/default.json
+++ b/src/config_logs/default.json
@@ -1,0 +1,15 @@
+{
+  "name": "default",
+  "displayName": "Default",
+  "rules": [
+    {
+      "sources": [],
+      "attributes": [
+        {
+          "key": "content",
+          "pattern": "@"
+        }
+      ]
+    }
+  ]
+}

--- a/src/lib/context.py
+++ b/src/lib/context.py
@@ -14,6 +14,7 @@
 
 import enum
 import os
+import traceback
 from datetime import datetime, timedelta
 from queue import Queue
 from typing import Optional
@@ -36,6 +37,10 @@ class LoggingContext:
 
     def error(self, *args):
         self.log("ERROR", *args)
+
+    def exception(self, *args):
+        self.error(*args)
+        traceback.print_exc()
 
     def log(self, *args):
         """

--- a/src/lib/logs/dynatrace_client.py
+++ b/src/lib/logs/dynatrace_client.py
@@ -50,7 +50,7 @@ def send_logs(context: LogsContext, logs: List[Dict]):
                 headers={
                     "Authorization": f"Api-Token {context.dynatrace_api_key}",
                     "Content-Type": "application/json; charset=utf-8"
-                },
+                }
             )
             if status > 299:
                 context.error(f'Log ingest error: {status}, reason: {reason}, url: {log_ingest_url}, body: "{response}"')

--- a/src/lib/logs/jmespath.py
+++ b/src/lib/logs/jmespath.py
@@ -1,0 +1,45 @@
+#   Copyright 2021 Dynatrace LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import re
+
+import jmespath
+from jmespath import functions
+
+
+class MappingCustomFunctions(functions.Functions):
+    # pylint: disable=R0201
+
+    @functions.signature({'types': ['string']},
+                         {'types': ['string']},
+                         {'types': ['string']})
+    def _func_replace_regex(self, subject, regex, replacement):
+        # replace java capture group sign ($) to python one (\)
+        processed_replacement = re.sub(r'\$(\d+)+', '\\\\\\1', replacement)
+        compiled_regex = re.compile(regex)
+        result = compiled_regex.sub(processed_replacement, subject)
+        return result
+
+    @functions.signature({'types': []},
+                         {'types': ['expref']},
+                         {'types': ['expref']},
+                         {'types': []})
+    def _func_if(self, condition, if_true_expression, if_false_expression, node_scope):
+        if condition:
+            return if_true_expression.visit(if_true_expression.expression, node_scope)
+        else:
+            return if_false_expression.visit(if_false_expression.expression, node_scope)
+
+
+JMESPATH_OPTIONS = jmespath.Options(custom_functions=MappingCustomFunctions())

--- a/src/lib/logs/log_forwarder.py
+++ b/src/lib/logs/log_forwarder.py
@@ -41,7 +41,7 @@ def run_logs(logging_context: LoggingContext):
     subscriber_client = pubsub.SubscriberClient()
     subscription_path = subscriber_client.subscription_path(PROJECT_ID, SUBSCRIPTION_ID)
     logging_context.log(f"Subscribing on '{subscription_path}'")
-    flow_control = FlowControl(max_messages=MAX_MESSAGES_PROCESSED)
+    flow_control = FlowControl(max_messages=MAX_MESSAGES_PROCESSED-10)
     subscriber = subscriber_client.subscribe(
         subscription=subscription_path,
         callback=create_process_message_handler(job_queue),

--- a/src/lib/logs/logs_sending_worker.py
+++ b/src/lib/logs/logs_sending_worker.py
@@ -41,9 +41,13 @@ def create_logs_context(job_queue: Queue):
     )
 
 
-def _log_sending_worker_loop(execution_period_seconds : int, job_queue: Queue):
+def _log_sending_worker_loop(execution_period_seconds: int, job_queue: Queue):
     while True:
-        _loop_single_period(execution_period_seconds, job_queue)
+        try:
+            _loop_single_period(execution_period_seconds, job_queue)
+        except Exception:
+            print("Logs Sending Worker Loop Exception:")
+            traceback.print_exc()
 
 
 def _loop_single_period(execution_period_seconds: int, job_queue: Queue):

--- a/src/lib/logs/metadata_engine.py
+++ b/src/lib/logs/metadata_engine.py
@@ -1,0 +1,231 @@
+#   Copyright 2021 Dynatrace LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from os import listdir
+from os.path import isfile
+from typing import Dict, List, Optional, Any
+
+import jmespath
+
+from lib.context import LoggingContext
+from lib.logs.jmespath import JMESPATH_OPTIONS
+
+_CONDITION_COMPARATOR_MAP = {
+    "$eq".casefold(): lambda x, y: str(x).casefold() == str(y).casefold(),
+    "$prefix".casefold(): lambda x, y: str(x).casefold().startswith(str(y).casefold()),
+    "$contains".casefold(): lambda x, y: str(y).casefold() in str(x).casefold(),
+}
+
+_SOURCE_VALUE_EXTRACTOR_MAP = {
+    "resourceType".casefold(): lambda record, parsed_record: parsed_record.get("gcp.resource.type", None),
+}
+
+ATTRIBUTE_SEVERITY = "severity"
+
+ATTRIBUTE_DT_LOGPATH = "dt.logpath"
+
+ATTRIBUTE_TIMESTAMP = "timestamp"
+
+ATTRIBUTE_CONTENT = "content"
+
+ATTRIBUTE_CLOUD_REGION = "cloud.region"
+
+ATTRIBUTE_CLOUD_PROVIDER = "cloud.provider"
+
+ATTRIBUTE_GCP_REGION = "gcp.region"
+
+ATTRIBUTE_GCP_PROJECT_ID = "gcp.project.id"
+
+ATTRIBUTE_GCP_INSTANCE_ID = "gcp.instance.id"
+
+ATTRIBUTE_GCP_INSTANCE_NAME = "gcp.instance.name"
+
+ATTRIBUTE_GCP_RESOURCE_TYPE = "gcp.resource.type"
+
+DEFAULT_RULE_NAME = "default"
+
+COMMON_RULE_NAME = "common"
+
+SPECIAL_RULE_NAMES = (DEFAULT_RULE_NAME, COMMON_RULE_NAME)
+
+@dataclass(frozen=True)
+class Attribute:
+    key: str
+    pattern: str
+
+
+class SourceMatcher:
+    source: str
+    condition: str
+    valid = True
+
+    _evaluator = None
+    _operand = None
+    _source_value_extractor = None
+
+    def __init__(self, context: LoggingContext, source: str, condition: str):
+        self.source = source
+        self.condition = condition
+        for key in _CONDITION_COMPARATOR_MAP:
+            if condition.startswith(key):
+                self._evaluator = _CONDITION_COMPARATOR_MAP[key]
+                break
+        operands = re.findall(r"'(.*?)'", condition, re.DOTALL)
+        self._operand = operands[0] if operands else None
+        self._source_value_extractor = _SOURCE_VALUE_EXTRACTOR_MAP.get(source.casefold(), None)
+
+        if not self._source_value_extractor:
+            context.log(f"Unsupported source type: '{source}'")
+            self.valid = False
+        if not self._evaluator or not self._operand:
+            context.log(f"Failed to parse condition macro for expression: '{condition}'")
+            self.valid = False
+
+    def match(self, record: Dict, parsed_record: Dict) -> bool:
+        value = self._extract_value(record, parsed_record)
+        return self._evaluator(value, self._operand)
+
+    def _extract_value(self, record: Dict, parsed_record: Dict) -> Any:
+        return self._source_value_extractor(record, parsed_record)
+
+
+@dataclass(frozen=True)
+class ConfigRule:
+    entity_type_name: str
+    source_matchers: List[SourceMatcher]
+    attributes: List[Attribute]
+
+
+class MetadataEngine:
+    rules: List[ConfigRule]
+    default_rule: ConfigRule = None
+    common_rule: ConfigRule = None
+    context: LoggingContext
+
+    def __init__(self):
+        self.rules = []
+        self._load_configs()
+
+    def _load_configs(self):
+        context = LoggingContext("ME startup")
+        working_directory = os.path.dirname(os.path.realpath(__file__))
+        config_directory = os.path.join(working_directory, "../../config_logs")
+        config_files = [
+            file for file
+            in listdir(config_directory)
+            if isfile(os.path.join(config_directory, file)) and _is_json_file(file)
+        ]
+        for file in config_files:
+            config_file_path = os.path.join(config_directory, file)
+            try:
+                with open(config_file_path) as config_file:
+                    config_json = json.load(config_file)
+                    if config_json.get("name", "") == DEFAULT_RULE_NAME:
+                        self.default_rule = _create_config_rules(context, config_json)[0]
+                    elif config_json.get("name", "") == COMMON_RULE_NAME:
+                        self.common_rule = _create_config_rules(context, config_json)[0]
+                    else:
+                        self.rules.extend(_create_config_rules(context, config_json))
+            except Exception as e:
+                context.exception(f"Failed to load configuration file: '{config_file_path}'")
+
+    def apply(self, context: LoggingContext, record: Dict, parsed_record: Dict):
+        try:
+            if self.common_rule:
+                _apply_rule(context, self.common_rule, record, parsed_record)
+            for rule in self.rules:
+                if _check_if_rule_applies(rule, record, parsed_record):
+                    _apply_rule(context, rule, record, parsed_record)
+                    return
+            # No matching rule has been found, applying the default rule
+            if self.default_rule:
+                _apply_rule(context, self.default_rule, record, parsed_record)
+        except Exception:
+            context.exception("Encountered exception when running Rule Engine")
+
+
+def _check_if_rule_applies(rule: ConfigRule, record: Dict, parsed_record: Dict):
+    return all(matcher.match(record, parsed_record) for matcher in rule.source_matchers)
+
+
+def _apply_rule(context: LoggingContext, rule: ConfigRule, record: Dict, parsed_record: Dict):
+    for attribute in rule.attributes:
+        try:
+            value = jmespath.search(attribute.pattern, record, JMESPATH_OPTIONS)
+            if value:
+                parsed_record[attribute.key] = value
+        except Exception:
+            context.exception(f"Encountered exception when evaluating attribute {attribute} of rule for {rule.entity_type_name}")
+
+
+def _create_sources(context: LoggingContext, sources_json: List[Dict]) -> List[SourceMatcher]:
+    result = []
+
+    for source_json in sources_json:
+        source = source_json.get("source", None)
+        condition = source_json.get("condition", None)
+        source_matcher = None
+
+        if source and condition:
+            source_matcher = SourceMatcher(context, source, condition)
+
+        if source_matcher and source_matcher.valid:
+            result.append(source_matcher)
+        else:
+            context.log(f"Encountered invalid rule source, parameters were: source= {source}, condition = {condition}")
+            return []
+
+    return result
+
+
+def _create_attributes(context: LoggingContext, attributes_json: List[Dict]) -> List[Attribute]:
+    result = []
+
+    for source_json in attributes_json:
+        key = source_json.get("key", None)
+        pattern = source_json.get("pattern", None)
+
+        if key and pattern:
+            result.append(Attribute(key, pattern))
+        else:
+            context.log(f"Encountered invalid rule attribute with missing parameter, parameters were: key = {key}, pattern = {pattern}")
+
+    return result
+
+
+def _create_config_rule(context: LoggingContext, entity_name: str, rule_json: Dict) -> Optional[ConfigRule]:
+    sources_json = rule_json.get("sources", [])
+    if entity_name not in SPECIAL_RULE_NAMES and not sources_json:
+        context.log(f"Encountered invalid rule with missing sources for config entry named {entity_name}")
+        return None
+    sources = _create_sources(context, sources_json)
+    if entity_name not in SPECIAL_RULE_NAMES and not sources:
+        context.log(f"Encountered invalid rule with invalid sources for config entry named {entity_name}: {sources_json}")
+        return None
+    attributes = _create_attributes(context, rule_json.get("attributes", []))
+    return ConfigRule(entity_type_name=entity_name, source_matchers=sources, attributes=attributes)
+
+
+def _create_config_rules(context: LoggingContext, config_json: Dict) -> List[ConfigRule]:
+    name = config_json.get("name", "")
+    created_rules = [_create_config_rule(context, name, rule_json) for rule_json in config_json.get("rules", [])]
+    return [created_rule for created_rule in created_rules if created_rule is not None]
+
+
+def _is_json_file(file: str) -> bool:
+    return file.endswith(".json")

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,10 @@
+# metrics
 aiohttp==3.7.4
 aiodns==2.0.0
 mmh3==2.5.1
 PyJWT==1.7.1
 PyYAML==5.4
+# logs
 google-cloud-pubsub==2.4.0
 python-dateutil==2.8.1
+jmespath~=0.10.0

--- a/tests/unit/extraction_rules/test_cloud_function.py
+++ b/tests/unit/extraction_rules/test_cloud_function.py
@@ -12,12 +12,15 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 import json
+from datetime import datetime
 
 from lib.context import LoggingContext
 from lib.logs.logs_processor import _create_dt_log_payload
 from lib.logs.metadata_engine import ATTRIBUTE_GCP_PROJECT_ID, ATTRIBUTE_GCP_RESOURCE_TYPE, ATTRIBUTE_SEVERITY, \
     ATTRIBUTE_CLOUD_PROVIDER, ATTRIBUTE_CLOUD_REGION, ATTRIBUTE_GCP_REGION, ATTRIBUTE_GCP_INSTANCE_NAME, \
     ATTRIBUTE_CONTENT, ATTRIBUTE_TIMESTAMP, ATTRIBUTE_DT_LOGPATH
+
+timestamp = datetime.utcnow().isoformat() + "Z"
 
 record = {
     "insertId": "000000-34c62aef-5df9-4f63-b692-a92f64febd2c",
@@ -36,7 +39,7 @@ record = {
     },
     "severity": "DEBUG",
     "textPayload": "Function execution started",
-    "timestamp": "2021-04-13T10:27:01.747066421Z",
+    "timestamp": timestamp,
     "trace": "projects/dynatrace-gcp-extension/traces/b24dd86d3aa6a386ff2aa6a7f16660a0"
 }
 
@@ -51,7 +54,7 @@ expected_output = {
     ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
     ATTRIBUTE_GCP_RESOURCE_TYPE: 'cloud_function',
     ATTRIBUTE_GCP_INSTANCE_NAME: 'dynatrace-gcp-function',
-    ATTRIBUTE_TIMESTAMP: '2021-04-13T10:27:01.747066421Z',
+    ATTRIBUTE_TIMESTAMP: timestamp,
     ATTRIBUTE_CONTENT: "Function execution started",
     ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudfunctions.googleapis.com%2Fcloud-functions',
     'faas.id': 'j22o0ucdhpop'

--- a/tests/unit/extraction_rules/test_cloud_function.py
+++ b/tests/unit/extraction_rules/test_cloud_function.py
@@ -1,0 +1,63 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import json
+
+from lib.context import LoggingContext
+from lib.logs.logs_processor import _create_dt_log_payload
+from lib.logs.metadata_engine import ATTRIBUTE_GCP_PROJECT_ID, ATTRIBUTE_GCP_RESOURCE_TYPE, ATTRIBUTE_SEVERITY, \
+    ATTRIBUTE_CLOUD_PROVIDER, ATTRIBUTE_CLOUD_REGION, ATTRIBUTE_GCP_REGION, ATTRIBUTE_GCP_INSTANCE_NAME, \
+    ATTRIBUTE_CONTENT, ATTRIBUTE_TIMESTAMP, ATTRIBUTE_DT_LOGPATH
+
+record = {
+    "insertId": "000000-34c62aef-5df9-4f63-b692-a92f64febd2c",
+    "labels": {
+        "execution_id": "j22o0ucdhpop"
+    },
+    "logName": "projects/dynatrace-gcp-extension/logs/cloudfunctions.googleapis.com%2Fcloud-functions",
+    "receiveTimestamp": "2021-04-13T10:27:11.946869081Z",
+    "resource": {
+        "labels": {
+            "function_name": "dynatrace-gcp-function",
+            "project_id": "dynatrace-gcp-extension",
+            "region": "us-central1"
+        },
+        "type": "cloud_function"
+    },
+    "severity": "DEBUG",
+    "textPayload": "Function execution started",
+    "timestamp": "2021-04-13T10:27:01.747066421Z",
+    "trace": "projects/dynatrace-gcp-extension/traces/b24dd86d3aa6a386ff2aa6a7f16660a0"
+}
+
+
+record_string = json.dumps(record)
+
+expected_output = {
+    ATTRIBUTE_SEVERITY: 'DEBUG',
+    ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+    ATTRIBUTE_CLOUD_REGION: 'us-central1',
+    ATTRIBUTE_GCP_REGION: 'us-central1',
+    ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+    ATTRIBUTE_GCP_RESOURCE_TYPE: 'cloud_function',
+    ATTRIBUTE_GCP_INSTANCE_NAME: 'dynatrace-gcp-function',
+    ATTRIBUTE_TIMESTAMP: '2021-04-13T10:27:01.747066421Z',
+    ATTRIBUTE_CONTENT: "Function execution started",
+    ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudfunctions.googleapis.com%2Fcloud-functions',
+    'faas.id': 'j22o0ucdhpop'
+}
+
+
+def test_extraction():
+    actual_output = _create_dt_log_payload(LoggingContext("TEST"), record_string)
+    assert actual_output == expected_output

--- a/tests/unit/extraction_rules/test_default.py
+++ b/tests/unit/extraction_rules/test_default.py
@@ -12,12 +12,15 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 import json
+from datetime import datetime
 
 from lib.context import LoggingContext
 from lib.logs.logs_processor import _create_dt_log_payload
 from lib.logs.metadata_engine import ATTRIBUTE_GCP_PROJECT_ID, ATTRIBUTE_GCP_RESOURCE_TYPE, ATTRIBUTE_SEVERITY, \
     ATTRIBUTE_CLOUD_PROVIDER, ATTRIBUTE_CLOUD_REGION, ATTRIBUTE_GCP_REGION, ATTRIBUTE_CONTENT, ATTRIBUTE_TIMESTAMP, \
     ATTRIBUTE_DT_LOGPATH
+
+timestamp = datetime.utcnow().isoformat() + "Z"
 
 record = {
     "insertId": "6075332400049b1f937691ca",
@@ -37,7 +40,7 @@ record = {
         "type": "cloud_run_revision"
     },
     "textPayload": "Saved 6333542b-b5fd-4996-8138-8b86e8156e29: ",
-    "timestamp": "2021-04-13T05:59:00.301855Z"
+    "timestamp": timestamp
 }
 
 record_string = json.dumps(record)
@@ -48,7 +51,7 @@ expected_output = {
     ATTRIBUTE_GCP_REGION: 'us-central1',
     ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
     ATTRIBUTE_GCP_RESOURCE_TYPE: 'cloud_run_revision',
-    ATTRIBUTE_TIMESTAMP: '2021-04-13T05:59:00.301855Z',
+    ATTRIBUTE_TIMESTAMP: timestamp,
     ATTRIBUTE_CONTENT: record_string,
     ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/run.googleapis.com%2Fstdout'
 }

--- a/tests/unit/extraction_rules/test_default.py
+++ b/tests/unit/extraction_rules/test_default.py
@@ -1,0 +1,59 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import json
+
+from lib.context import LoggingContext
+from lib.logs.logs_processor import _create_dt_log_payload
+from lib.logs.metadata_engine import ATTRIBUTE_GCP_PROJECT_ID, ATTRIBUTE_GCP_RESOURCE_TYPE, ATTRIBUTE_SEVERITY, \
+    ATTRIBUTE_CLOUD_PROVIDER, ATTRIBUTE_CLOUD_REGION, ATTRIBUTE_GCP_REGION, ATTRIBUTE_CONTENT, ATTRIBUTE_TIMESTAMP, \
+    ATTRIBUTE_DT_LOGPATH
+
+record = {
+    "insertId": "6075332400049b1f937691ca",
+    "labels": {
+        "instanceId": "00bf4bf02d68c4b9968ace4f97f127bad96e1f32a0cb3d624ed74842c248e63867a0376c37fea457fa18dbb0c5a6315fe54e96754df0b8998e2cdfebac"
+    },
+    "logName": "projects/dynatrace-gcp-extension/logs/run.googleapis.com%2Fstdout",
+    "receiveTimestamp": "2021-04-13T05:59:00.305070638Z",
+    "resource": {
+        "labels": {
+            "configuration_name": "datastore-test",
+            "location": "us-central1",
+            "project_id": "dynatrace-gcp-extension",
+            "revision_name": "datastore-test-00002-hot",
+            "service_name": "datastore-test"
+        },
+        "type": "cloud_run_revision"
+    },
+    "textPayload": "Saved 6333542b-b5fd-4996-8138-8b86e8156e29: ",
+    "timestamp": "2021-04-13T05:59:00.301855Z"
+}
+
+record_string = json.dumps(record)
+
+expected_output = {
+    ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+    ATTRIBUTE_CLOUD_REGION: 'us-central1',
+    ATTRIBUTE_GCP_REGION: 'us-central1',
+    ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+    ATTRIBUTE_GCP_RESOURCE_TYPE: 'cloud_run_revision',
+    ATTRIBUTE_TIMESTAMP: '2021-04-13T05:59:00.301855Z',
+    ATTRIBUTE_CONTENT: record_string,
+    ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/run.googleapis.com%2Fstdout'
+}
+
+
+def test_extraction():
+    actual_output = _create_dt_log_payload(LoggingContext("TEST"), record_string)
+    assert actual_output == expected_output

--- a/tests/unit/test_metadata_engine.py
+++ b/tests/unit/test_metadata_engine.py
@@ -1,0 +1,66 @@
+#   Copyright 2021 Dynatrace LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from lib.context import LoggingContext
+from lib.logs.metadata_engine import SourceMatcher, _create_config_rule
+
+context = LoggingContext("TEST")
+
+
+def test_resource_type_eq_source_matcher():
+    matcher = SourceMatcher(context, "resourceType", "$eq('TEST')")
+    assert matcher.match({}, {"gcp.resource.type": "TEST"})
+    assert not matcher.match({}, {"gcp.resource.type": "NOT_TEST"})
+    assert not matcher.match({}, {})
+
+
+def test_resource_type_contains_source_matcher():
+    matcher = SourceMatcher(context, "resourceType", "$contains('TEST')")
+    assert matcher.match({}, {"gcp.resource.type": "GCP_TEST"})
+    assert not matcher.match({}, {"gcp.resource.type": "BEST"})
+    assert not matcher.match({}, {})
+
+
+def test_resource_type_prefix_source_matcher():
+    matcher = SourceMatcher(context, "resourceType", "$prefix('TEST')")
+    assert matcher.match({}, {"gcp.resource.type": "TEST_GCP"})
+    assert not matcher.match({}, {"gcp.resource.type": "GCP_TEST"})
+    assert not matcher.match({}, {})
+
+
+def test_create_valid_config_rule():
+    rule_json = {
+        "sources": [{"sourceType": "logs", "source": "resourceType", "condition": "$eq('MICROSOFT.APIMANAGEMENT/SERVICE')"}]
+    }
+    assert _create_config_rule(context, "TEST", rule_json)
+
+
+def test_create_invalid_config_rule_source_missing_field():
+    rule_json = {
+        "sources": [{"sourceType": "logs", "condition": "$eq('MICROSOFT.APIMANAGEMENT/SERVICE')"}]
+    }
+    assert not _create_config_rule(context, "TEST", rule_json)
+
+
+def test_create_invalid_config_rule_invalid_source():
+    rule_json = {
+        "sources": [{"sourceType": "logs", "source": "INVALID", "condition": "$eq('MICROSOFT.APIMANAGEMENT/SERVICE')"}]
+    }
+    assert not _create_config_rule(context, "TEST", rule_json)
+
+
+def test_default_rule_can_have_no_sources():
+    rule_json = {
+        "sources": []
+    }
+    assert _create_config_rule(context, "default", rule_json)


### PR DESCRIPTION
This PR introduces Metadata Engine for GCP Logs Forwarder. Engine is the same as in Azure Logs Forwarder, with small tweak - `common.json` configuration has been introduced. This ruleset is evaluated before any other rules. This is meant to address the fact that GCP log message is well defined and structured, so without we would have a lot of duplicated rules across configurations. Simple config for Cloud Function has been introduced only as a proof that rules are correctly evaluated.

When developing I came across weird issue with full internal message queue, I wasn't able to reproduce it, but I suspect that due to my internet connection issues, requests to Dynatrace were timing out. To mitigate it in future, I've introduced a couple small tweaks:
- defined 30 second timeout for requests (library default is 60 seconds, too much for our 1 minute loop)
- set `FlowControl.maxMessages` to be 10 messages smaller than internal payload queue
- introduce yet another layer of error handling in log forwarding loop