### PR TITLE
[APM-293900] support separate config entry for logs ingest Dynatrace endpoint

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -9,7 +9,9 @@ to install all the dependencies run
 pip install -r requirements.txt
 ```
 
-To run worker function run `local_test.py` script file. 
+To run metrics ingest worker function run `local_test.py` script file.
+
+To run logs ingest worker function run `local_test.py` script file with `OPERATION_MODE` set to `Logs` 
 
 ## Environment variables
 
@@ -37,7 +39,7 @@ Worker function execution can be tweaked with environment variables. In Google F
 | Variable name | description   | default value |
 | ----------------- | ------------- | ----------- |
 | DYNATRACE_ACCESS_KEY_SECRET_NAME | name of environment variable or Google Secret Manager Secret containing Dynatrace Access Key | DYNATRACE_ACCESS_KEY |
-| DYNATRACE_URL_SECRET_NAME | name of environment variable or Google Secret Manager Secret containing Dynatrace URL | DYNATRACE_URL |
+| DYNATRACE_LOG_INGEST_URL_SECRET_NAME | name of environment variable or Google Secret Manager Secret containing Dynatrace URL | DYNATRACE_LOG_INGEST_URL |
 | GOOGLE_APPLICATION_CREDENTIALS | path to GCP service account key file | |
 | REQUIRE_VALID_CERTIFICATE | determines whether worker will verify SSL certificate of Dynatrace endpoint | True |
 | DYNATRACE_LOG_INGEST_CONTENT_MAX_LENGTH | determines max content length of log event. Should be the same or lower than on cluster | 8192 characters |

--- a/activation-config.yaml
+++ b/activation-config.yaml
@@ -5,10 +5,8 @@ debug:
 googleCloud:
   common:
     # Name of Google Secret Manager Secret containing Dynatrace Access Key
-    dynatraceAccessKeySecretName: DYNATRACE_ACCESS_KEY 
-    # Name of Google Secret Manager Secret containing Dynatrace URL
-    dynatraceUrlSecretName: DYNATRACE_URL
-    # Name of the Service Account that should be created for Dynatrace Function to authenticate with Google Monitoring API 
+    dynatraceAccessKeySecretName: DYNATRACE_ACCESS_KEY
+    # Name of the Service Account that should be created for Dynatrace Function to authenticate with Google Monitoring API
     serviceAccount: dynatrace-gcp-service
     # Path to Google credentials file
     # googleApplicationCredentialsPath: ''
@@ -26,6 +24,8 @@ googleCloud:
     # Import predefined alerts (`yes`: enabled, `inactive`: disabled) for selected services (yes/inactive/no)
     importAlerts: yes
   metrics:
+    # Name of Google Secret Manager Secret containing Dynatrace URL
+    dynatraceUrlSecretName: DYNATRACE_URL
     # Name of the Pub/Sub topic for metric function
     pubSubTopic: dynatrace-gcp-service-invocation
     # Name of the metric forwarding function 
@@ -35,6 +35,8 @@ googleCloud:
     # Cron schedule for Cloud Scheduler instance
     schedulerSchedule: "* * * * *" 
   logs:
+    # Name of Google Secret Manager Secret containing Dynatrace logs ingest URL
+    dynatraceUrlSecretName: DYNATRACE_LOG_INGEST_URL
     # Name of the log forwarding function
     function: dynatrace-gcp-logs-function
     # Prefix for Log Router Sink for log forwarding function

--- a/activation-config.yaml
+++ b/activation-config.yaml
@@ -4,6 +4,8 @@ debug:
   printMetricIngestInput: false 
 googleCloud:
   common:
+    # Name of Google Secret Manager Secret containing Dynatrace URL
+    dynatraceUrlSecretName: DYNATRACE_URL
     # Name of Google Secret Manager Secret containing Dynatrace Access Key
     dynatraceAccessKeySecretName: DYNATRACE_ACCESS_KEY
     # Name of the Service Account that should be created for Dynatrace Function to authenticate with Google Monitoring API
@@ -24,8 +26,6 @@ googleCloud:
     # Import predefined alerts (`yes`: enabled, `inactive`: disabled) for selected services (yes/inactive/no)
     importAlerts: yes
   metrics:
-    # Name of Google Secret Manager Secret containing Dynatrace URL
-    dynatraceUrlSecretName: DYNATRACE_URL
     # Name of the Pub/Sub topic for metric function
     pubSubTopic: dynatrace-gcp-service-invocation
     # Name of the metric forwarding function 
@@ -34,13 +34,6 @@ googleCloud:
     scheduler: dynatrace-gcp-schedule
     # Cron schedule for Cloud Scheduler instance
     schedulerSchedule: "* * * * *" 
-  logs:
-    # Name of Google Secret Manager Secret containing Dynatrace logs ingest URL
-    dynatraceUrlSecretName: DYNATRACE_LOG_INGEST_URL
-    # Name of the log forwarding function
-    function: dynatrace-gcp-logs-function
-    # Prefix for Log Router Sink for log forwarding function
-    log-sink-prefix: dynatrace-log-sink_ 
 activation:
   metrics:
     # List of services to forward Google Monitoring Metrics to Dynatrace

--- a/k8s/helm-chart/dynatrace-gcp-function/templates/template.yml
+++ b/k8s/helm-chart/dynatrace-gcp-function/templates/template.yml
@@ -130,13 +130,13 @@ spec:
               key: REQUIRE_VALID_CERTIFICATE
         - name: DYNATRACE_ACCESS_KEY_SECRET_NAME
           value: DYNATRACE_ACCESS_KEY
-        - name: DYNATRACE_URL_SECRET_NAME
-          value: DYNATRACE_URL
-        - name: DYNATRACE_URL
+        - name: DYNATRACE_LOG_INGEST_URL_SECRET_NAME
+          value: DYNATRACE_LOG_INGEST_URL
+        - name: DYNATRACE_LOG_INGEST_URL
           valueFrom:
             secretKeyRef:
               name: dynatrace-gcp-function-secret
-              key: url
+              key: log-ingest-url
         - name: DYNATRACE_ACCESS_KEY
           valueFrom:
             secretKeyRef:

--- a/src/lib/credentials.py
+++ b/src/lib/credentials.py
@@ -32,7 +32,6 @@ _DYNATRACE_URL_SECRET_NAME = os.environ.get("DYNATRACE_URL_SECRET_NAME","DYNATRA
 _DYNATRACE_LOG_INGEST_URL_SECRET_NAME = os.environ.get("DYNATRACE_LOG_INGEST_URL_SECRET_NAME","DYNATRACE_LOG_INGEST_URL")
 
 
-
 async def fetch_dynatrace_api_key(gcp_session: ClientSession, project_id: str, token: str, ):
     return await fetch_secret(gcp_session, project_id, token, _DYNATRACE_ACCESS_KEY_SECRET_NAME)
 

--- a/src/lib/credentials.py
+++ b/src/lib/credentials.py
@@ -29,6 +29,8 @@ _METADATA_HEADERS = {_METADATA_FLAVOR_HEADER: _METADATA_FLAVOR_VALUE}
 
 _DYNATRACE_ACCESS_KEY_SECRET_NAME = os.environ.get("DYNATRACE_ACCESS_KEY_SECRET_NAME", "DYNATRACE_ACCESS_KEY")
 _DYNATRACE_URL_SECRET_NAME = os.environ.get("DYNATRACE_URL_SECRET_NAME","DYNATRACE_URL")
+_DYNATRACE_LOG_INGEST_URL_SECRET_NAME = os.environ.get("DYNATRACE_LOG_INGEST_URL_SECRET_NAME","DYNATRACE_LOG_INGEST_URL")
+
 
 
 async def fetch_dynatrace_api_key(gcp_session: ClientSession, project_id: str, token: str, ):
@@ -43,8 +45,13 @@ def get_dynatrace_api_key_from_env():
     return os.environ.get(_DYNATRACE_ACCESS_KEY_SECRET_NAME, None)
 
 
-def get_dynatrace_url_from_env():
-    return os.environ.get(_DYNATRACE_URL_SECRET_NAME, None)
+def get_dynatrace_log_ingest_url_from_env():
+    # TODO alternatively fetch from GCP secret
+    #return await fetch_secret(gcp_session, project_id, token, _DYNATRACE_URL_SECRET_NAME)
+    url = os.environ.get(_DYNATRACE_LOG_INGEST_URL_SECRET_NAME, None)
+    if url is None:
+        raise Exception("{env_var} environment variable is not set".format(env_var=_DYNATRACE_LOG_INGEST_URL_SECRET_NAME))
+    return url
 
 
 async def fetch_secret(session: ClientSession, project_id: str, token: str, secret_name: str):

--- a/src/lib/credentials.py
+++ b/src/lib/credentials.py
@@ -46,8 +46,6 @@ def get_dynatrace_api_key_from_env():
 
 
 def get_dynatrace_log_ingest_url_from_env():
-    # TODO alternatively fetch from GCP secret
-    #return await fetch_secret(gcp_session, project_id, token, _DYNATRACE_URL_SECRET_NAME)
     url = os.environ.get(_DYNATRACE_LOG_INGEST_URL_SECRET_NAME, None)
     if url is None:
         raise Exception("{env_var} environment variable is not set".format(env_var=_DYNATRACE_LOG_INGEST_URL_SECRET_NAME))

--- a/src/lib/logs/logs_sending_worker.py
+++ b/src/lib/logs/logs_sending_worker.py
@@ -18,7 +18,7 @@ from time import sleep, time
 from typing import List, Callable
 
 from lib.context import LogsContext
-from lib.credentials import get_dynatrace_api_key_from_env, get_dynatrace_url_from_env, get_project_id_from_environment
+from lib.credentials import get_dynatrace_api_key_from_env, get_dynatrace_log_ingest_url_from_env, get_project_id_from_environment
 from lib.logs.dynatrace_client import send_logs
 from lib.logs.logs_processor import LogProcessingJob
 
@@ -29,7 +29,7 @@ def create_log_sending_worker_loop(execution_period_seconds : int, job_queue: Qu
 
 def create_logs_context(job_queue: Queue):
     dynatrace_api_key = get_dynatrace_api_key_from_env()
-    dynatrace_url = get_dynatrace_url_from_env()
+    dynatrace_url = get_dynatrace_log_ingest_url_from_env()
     project_id_owner = get_project_id_from_environment()
 
     return LogsContext(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -41,7 +41,7 @@ MonkeyPatchFixture = NewType("MonkeyPatchFixture", Any)
 system_variables = {
     # 'DYNATRACE_LOG_INGEST_CONTENT_MAX_LENGTH': str(500),
     'DYNATRACE_LOG_INGEST_REQUEST_MAX_SIZE': str(5 * 1024),
-    'DYNATRACE_URL': 'http://localhost:' + str(MOCKED_API_PORT),
+    'DYNATRACE_LOG_INGEST_URL': 'http://localhost:' + str(MOCKED_API_PORT),
     'DYNATRACE_ACCESS_KEY': ACCESS_KEY,
     'REQUIRE_VALID_CERTIFICATE': 'False'
 }


### PR DESCRIPTION
Added possibility to use sepatate endpoint for metrics (MINT API on cluster server) and logs (Generic Logs Ingest API on ActiveGate node)
