### PR TITLE
Fix len() Exception when limiting dimension value size

### DIFF
--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -15,7 +15,7 @@ import os
 import time
 from datetime import timezone, datetime
 from http.client import InvalidURL
-from typing import Dict, List
+from typing import Dict, List, Any
 
 from lib.context import LoggingContext, Context, DynatraceConnectivity
 from lib.entities.ids import _create_mmh3_hash
@@ -209,15 +209,17 @@ def extract_typed_value_key(time_serie):
     return typed_value_key
 
 
-def create_dimension(name: str, value: str, context: LoggingContext = LoggingContext(None)) -> DimensionValue:
+def create_dimension(name: str, value: Any, context: LoggingContext = LoggingContext(None)) -> DimensionValue:
+    string_value = str(value)
+
     if len(name) > MAX_DIMENSION_NAME_LENGTH:
         context.log(f'MINT rejects dimension names longer that {MAX_DIMENSION_NAME_LENGTH} chars. Dimension name \"{name}\" "has been truncated')
         name = name[:MAX_DIMENSION_NAME_LENGTH]
-    if len(value) > MAX_DIMENSION_VALUE_LENGTH:
-        context.log(f'MINT rejects dimension values longer that {MAX_DIMENSION_VALUE_LENGTH} chars. Dimension value \"{value}\" has been truncated')
-        value = value[:MAX_DIMENSION_VALUE_LENGTH]
+    if len(string_value) > MAX_DIMENSION_VALUE_LENGTH:
+        context.log(f'MINT rejects dimension values longer that {MAX_DIMENSION_VALUE_LENGTH} chars. Dimension value \"{string_value}\" has been truncated')
+        string_value = string_value[:MAX_DIMENSION_VALUE_LENGTH]
 
-    return DimensionValue(name, value)
+    return DimensionValue(name, string_value)
 
 
 def create_dimensions(context: Context, time_serie: Dict) -> List[DimensionValue]:

--- a/src/main.py
+++ b/src/main.py
@@ -143,13 +143,17 @@ async def handle_event(event: Dict, event_context, project_id_owner: Optional[st
 
 
 async def process_project_metrics(context: Context, project_id: str, services: List[GCPService]):
-    context.log(project_id, f"Starting processing...")
-    await check_x_goog_user_project_header_permissions(context, project_id)
-    ingest_lines = await fetch_ingest_lines_task(context, project_id, services)
-    fetch_data_time = time.time() - context.start_processing_timestamp
-    context.fetch_gcp_data_execution_time[project_id] = fetch_data_time
-    context.log(project_id, f"Finished fetching data in {fetch_data_time}")
-    await push_ingest_lines(context, project_id, ingest_lines)
+    try:
+        context.log(project_id, f"Starting processing...")
+        await check_x_goog_user_project_header_permissions(context, project_id)
+        ingest_lines = await fetch_ingest_lines_task(context, project_id, services)
+        fetch_data_time = time.time() - context.start_processing_timestamp
+        context.fetch_gcp_data_execution_time[project_id] = fetch_data_time
+        context.log(project_id, f"Finished fetching data in {fetch_data_time}")
+        await push_ingest_lines(context, project_id, ingest_lines)
+    except Exception as e:
+        context.log(f"Failed to finish processing due to {e}")
+        traceback.print_exc()
 
 
 async def check_x_goog_user_project_header_permissions(context: Context, project_id: str):


### PR DESCRIPTION
Some of dimension values may have different type than `str`, which triggers error on `len()` call. I've added error logging clause on `process_project_metrics`, because before it could swallow errors quietly.