### PR TITLE
GCP Function HTTPS_PROXY and HTTP_PROXY environment variables are defined in config map

### DIFF
--- a/k8s/dynatrace-gcp-function.yaml
+++ b/k8s/dynatrace-gcp-function.yaml
@@ -29,6 +29,9 @@ data:
   # if set to GCP_ONLY: proxy settings will be used only for requests to GCP API
   # if not set: default, proxy settings won't be used
   USE_PROXY: ""
+  # Set the proxy addresses. To be used in conjunction with USE_PROXY.
+  HTTP_PROXY: ""
+  HTTPS_PROXY: ""
   # Import predefined dashboards for selected services. Allowed values: `yes`, `no`
   IMPORT_DASHBOARDS: "yes"
   # Import predefined alerting rules (inactive by default) for selected services. Allowed values: `yes`, `no`
@@ -95,6 +98,16 @@ spec:
             configMapKeyRef:
               name: dynatrace-gcp-function-config
               key: IMPORT_ALERTS
+        - name: HTTP_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: dynatrace-gcp-function-config
+                key: HTTP_PROXY
+        - name: HTTPS_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: dynatrace-gcp-function-config
+                key: HTTPS_PROXY
         - name: DYNATRACE_ACCESS_KEY_SECRET_NAME
           value: DYNATRACE_ACCESS_KEY
         - name: DYNATRACE_URL_SECRET_NAME


### PR DESCRIPTION
GCP Function HTTPS_PROXY and HTTP_PROXY environment variables are defined in config map