### PR TITLE
Update dynatrace-gcp-function.yaml

### DIFF
--- a/k8s/dynatrace-gcp-function.yaml
+++ b/k8s/dynatrace-gcp-function.yaml
@@ -104,15 +104,15 @@ spec:
               name: dynatrace-gcp-function-config
               key: IMPORT_ALERTS
         - name: HTTP_PROXY
-            valueFrom:
-              configMapKeyRef:
-                name: dynatrace-gcp-function-config
-                key: HTTP_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: dynatrace-gcp-function-config
+              key: HTTP_PROXY
         - name: HTTPS_PROXY
-            valueFrom:
-              configMapKeyRef:
-                name: dynatrace-gcp-function-config
-                key: HTTPS_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: dynatrace-gcp-function-config
+              key: HTTPS_PROXY
         - name: DYNATRACE_ACCESS_KEY_SECRET_NAME
           value: DYNATRACE_ACCESS_KEY
         - name: DYNATRACE_URL_SECRET_NAME


### PR DESCRIPTION
Wrong indentation results in parsing error while converting YAML to JSON during apply: "mapping values are not allowed in this context".
Indentation corrected.