### PR TITLE
APM-292701: Mapping Audit Logs

### DIFF
--- a/src/config_logs/cloud_audit_logs.json
+++ b/src/config_logs/cloud_audit_logs.json
@@ -1,0 +1,33 @@
+{
+  "name": "audit_logs",
+  "displayName": "Cloud Audit Logs",
+  "rules": [
+    {
+      "sources": [
+        {
+          "sourceType": "logs",
+          "source": "logName",
+          "condition": "$contains('cloudaudit.googleapis.com')"
+        }
+      ],
+      "attributes": [
+        {
+          "key": "audit.identity",
+          "pattern": "protoPayload.authenticationInfo.principalEmail || protoPayload.authenticationInfo.principalSubject"
+        },
+        {
+          "key": "audit.action",
+          "pattern": "protoPayload.methodName"
+        },
+        {
+          "key": "audit.result",
+          "pattern": "status_from_proto_code(protoPayload.status.code)"
+        },
+        {
+          "key": "content",
+          "pattern": "@"
+        }
+      ]
+    }
+  ]
+}

--- a/src/config_logs/common.json
+++ b/src/config_logs/common.json
@@ -15,11 +15,11 @@
         },
         {
           "key": "cloud.region",
-          "pattern": "resource.labels.region || resource.labels.location"
+          "pattern": "resource.labels.region || resource.labels.location || resource.labels.zone"
         },
         {
           "key": "gcp.region",
-          "pattern": "resource.labels.region || resource.labels.location"
+          "pattern": "resource.labels.region || resource.labels.location || resource.labels.zone"
         },
         {
           "key": "gcp.project.id",

--- a/src/lib/logs/jmespath.py
+++ b/src/lib/logs/jmespath.py
@@ -66,7 +66,7 @@ class MappingCustomFunctions(functions.Functions):
         if not proto_code:
             return "Succeeded"
         else:
-            return "Failure." + self.proto_error_code_to_string_dict.get(proto_code, "")
+            return "Failed." + self.proto_error_code_to_string_dict.get(proto_code, "")
 
 
 JMESPATH_OPTIONS = jmespath.Options(custom_functions=MappingCustomFunctions())

--- a/src/lib/logs/jmespath.py
+++ b/src/lib/logs/jmespath.py
@@ -41,5 +41,32 @@ class MappingCustomFunctions(functions.Functions):
         else:
             return if_false_expression.visit(if_false_expression.expression, node_scope)
 
+    # based on https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+    proto_error_code_to_string_dict = {
+        1:  "Cancelled",
+        2:  "Unknown",
+        3:  "InvalidArgument",
+        4:  "DeadlineExceeded",
+        5:  "NotFound",
+        6:  "AlreadyExists",
+        7:  "PermissionDenied",
+        8:  "ResourceExhausted",
+        9:  "FailedPrecondition",
+        10: "Aborted",
+        11: "OutOfRange",
+        12: "Unimplemented",
+        13: "Internal",
+        14: "Unavailable",
+        15: "DataLoss",
+        16: "Unauthenticated"
+    }
+
+    @functions.signature({'types': []})
+    def _func_status_from_proto_code(self, proto_code):
+        if not proto_code:
+            return "Succeeded"
+        else:
+            return "Failure." + self.proto_error_code_to_string_dict.get(proto_code, "")
+
 
 JMESPATH_OPTIONS = jmespath.Options(custom_functions=MappingCustomFunctions())

--- a/tests/unit/extraction_rules/test_audit_activity.py
+++ b/tests/unit/extraction_rules/test_audit_activity.py
@@ -324,7 +324,7 @@ expected_output_list = [
         ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Factivity',
         ATTRIBUTE_AUDIT_IDENTITY: 'svc-gke-dynatrace-npd@mgmt-ple-prd-83f7.iam.gserviceaccount.com',
         ATTRIBUTE_AUDIT_ACTION: 'google.monitoring.v3.MetricService.CreateMetricDescriptor',
-        ATTRIBUTE_AUDIT_RESULT: 'Failure.PermissionDenied',
+        ATTRIBUTE_AUDIT_RESULT: 'Failed.PermissionDenied',
         ATTRIBUTE_SEVERITY: "ERROR"
     },
     {

--- a/tests/unit/extraction_rules/test_audit_activity.py
+++ b/tests/unit/extraction_rules/test_audit_activity.py
@@ -1,0 +1,370 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import json
+from datetime import datetime
+from queue import Queue
+from typing import NewType, Any
+
+from lib.context import LogsContext
+from lib.logs import logs_processor
+from lib.logs.metadata_engine import ATTRIBUTE_GCP_PROJECT_ID, ATTRIBUTE_GCP_RESOURCE_TYPE, ATTRIBUTE_SEVERITY, \
+    ATTRIBUTE_CLOUD_PROVIDER, ATTRIBUTE_CLOUD_REGION, ATTRIBUTE_GCP_REGION, ATTRIBUTE_CONTENT, ATTRIBUTE_TIMESTAMP, \
+    ATTRIBUTE_DT_LOGPATH, ATTRIBUTE_AUDIT_IDENTITY, ATTRIBUTE_AUDIT_ACTION, ATTRIBUTE_AUDIT_RESULT
+
+MonkeyPatchFixture = NewType("MonkeyPatchFixture", Any)
+
+timestamp = datetime.utcnow().isoformat() + "Z"
+
+record = {
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {
+            "principalEmail": "system:vpa-recommender"
+        },
+        "authorizationInfo": [
+            {
+                "granted": True,
+                "permission": "io.k8s.core.v1.endpoints.update",
+                "resource": "core/v1/namespaces/kube-system/endpoints/vpa-recommender"
+            }
+        ],
+        "methodName": "io.k8s.core.v1.endpoints.update",
+        "request": {
+            "@type": "core.k8s.io/v1.Endpoints",
+            "apiVersion": "v1",
+            "kind": "Endpoints",
+            "metadata": {
+                "annotations": {
+                    "control-plane.alpha.kubernetes.io/leader": "{\"holderIdentity\":\"gke-7c2765753c45498d9427-c6a4-ee8a-vm\",\"leaseDurationSeconds\":30,\"acquireTime\":\"2021-05-24T20:53:16Z\",\"renewTime\":\"2021-06-01T13:46:22Z\",\"leaderTransitions\":5}"
+                },
+                "creationTimestamp": "2021-05-05T11:17:10Z",
+                "managedFields": [
+                    {
+                        "apiVersion": "v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:control-plane.alpha.kubernetes.io/leader": {}
+                                }
+                            }
+                        },
+                        "manager": "vpa-recommender",
+                        "operation": "Update",
+                        "time": "2021-05-05T11:17:10Z"
+                    }
+                ],
+                "name": "vpa-recommender",
+                "namespace": "kube-system",
+                "resourceVersion": "13396222",
+                "selfLink": "/api/v1/namespaces/kube-system/endpoints/vpa-recommender",
+                "uid": "61da1c87-12aa-4425-896a-05cd375d7c99"
+            }
+        },
+        "requestMetadata": {
+            "callerIp": "::1",
+            "callerSuppliedUserAgent": "vpa-recommender/v0.0.0 (linux/amd64) kubernetes/$Format"
+        },
+        "resourceName": "core/v1/namespaces/kube-system/endpoints/vpa-recommender",
+        "response": {
+            "@type": "core.k8s.io/v1.Endpoints",
+            "apiVersion": "v1",
+            "kind": "Endpoints",
+            "metadata": {
+                "annotations": {
+                    "control-plane.alpha.kubernetes.io/leader": "{\"holderIdentity\":\"gke-7c2765753c45498d9427-c6a4-ee8a-vm\",\"leaseDurationSeconds\":30,\"acquireTime\":\"2021-05-24T20:53:16Z\",\"renewTime\":\"2021-06-01T13:46:22Z\",\"leaderTransitions\":5}"
+                },
+                "creationTimestamp": "2021-05-05T11:17:10Z",
+                "managedFields": [
+                    {
+                        "apiVersion": "v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:control-plane.alpha.kubernetes.io/leader": {}
+                                }
+                            }
+                        },
+                        "manager": "vpa-recommender",
+                        "operation": "Update",
+                        "time": "2021-05-05T11:17:10Z"
+                    }
+                ],
+                "name": "vpa-recommender",
+                "namespace": "kube-system",
+                "resourceVersion": "13396246",
+                "selfLink": "/api/v1/namespaces/kube-system/endpoints/vpa-recommender",
+                "uid": "61da1c87-12aa-4425-896a-05cd375d7c99"
+            }
+        },
+        "serviceName": "k8s.io",
+        "status": {
+            "code": 0
+        }
+    },
+    "insertId": "1eba2903-6843-4ef7-a903-51e7ccdbe585",
+    "resource": {
+        "type": "k8s_cluster",
+        "labels": {
+            "project_id": "dynatrace-gcp-extension",
+            "location": "us-central1-c",
+            "cluster_name": "mg-logs-docs-test"
+        }
+    },
+    "timestamp": timestamp,
+    "labels": {
+        "authorization.k8s.io/decision": "allow",
+        "authorization.k8s.io/reason": "RBAC: allowed by ClusterRoleBinding \"system:gke-controller\" of ClusterRole \"system:gke-controller\" to User \"system:vpa-recommender\""
+    },
+    "logName": "projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Factivity",
+    "operation": {
+        "id": "1eba2903-6843-4ef7-a903-51e7ccdbe585",
+        "producer": "k8s.io",
+        "first": True,
+        "last": True
+    },
+    "receiveTimestamp": "2021-06-01T13:46:24.606609316Z"
+}
+
+record2 = {
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "status": {
+            "code": 7,
+            "message": "Permission monitoring.metricDescriptors.create denied (or the resource may not exist)."
+        },
+        "authenticationInfo": {
+            "principalEmail": "svc-gke-dynatrace-npd@mgmt-ple-prd-83f7.iam.gserviceaccount.com"
+        },
+        "requestMetadata": {
+            "callerIp": "gce-internal-ip",
+            "callerSuppliedUserAgent": "Python/3.8 aiohttp/3.7.4,gzip(gfe)",
+            "requestAttributes": {
+                "time": "2021-06-01T13:46:13.799387360Z",
+                "auth": {}
+            },
+            "destinationAttributes": {}
+        },
+        "serviceName": "monitoring.googleapis.com",
+        "methodName": "google.monitoring.v3.MetricService.CreateMetricDescriptor",
+        "authorizationInfo": [
+            {
+                "resource": "125992521190",
+                "permission": "monitoring.metricDescriptors.create",
+                "resourceAttributes": {}
+            }
+        ],
+        "resourceName": "projects/dynatrace-gcp-extension",
+        "request": {
+            "@type": "type.googleapis.com/google.monitoring.v3.CreateMetricDescriptorRequest",
+            "name": "projects/dynatrace-gcp-extension",
+            "metricDescriptor": {
+                "monitoredResourceTypes": [
+                    "generic_task"
+                ],
+                "type": "custom.googleapis.com/dynatrace/phase_execution_time",
+                "unit": "s",
+                "metricKind": "GAUGE",
+                "valueType": "DOUBLE",
+                "displayName": "Dynatrace Integration Phase Execution Time",
+                "description": "Dynatrace integration self monitoring metric"
+            }
+        }
+    },
+    "insertId": "ziy2qeejg3ll",
+    "resource": {
+        "type": "audited_resource",
+        "labels": {
+            "method": "google.monitoring.v3.MetricService.CreateMetricDescriptor",
+            "project_id": "dynatrace-gcp-extension",
+            "service": "monitoring.googleapis.com"
+        }
+    },
+    "timestamp": timestamp,
+    "severity": "ERROR",
+    "logName": "projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Factivity",
+    "receiveTimestamp": "2021-06-01T13:46:13.923598562Z"
+}
+
+record3 = {
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "status": {},
+        "authenticationInfo": {
+            "principalEmail": "dynatrace-gcp-extension@appspot.gserviceaccount.com",
+            "serviceAccountDelegationInfo": [
+                {
+                    "firstPartyPrincipal": {
+                        "principalEmail": "app-engine-appserver@prod.google.com"
+                    }
+                }
+            ]
+        },
+        "requestMetadata": {
+            "callerIp": "x.x.x.x",
+            "requestAttributes": {
+                "time": "2021-06-01T13:28:03.152740Z",
+                "auth": {}
+            },
+            "destinationAttributes": {}
+        },
+        "serviceName": "cloudsql.googleapis.com",
+        "methodName": "cloudsql.instances.connect",
+        "authorizationInfo": [
+            {
+                "resource": "instances/pawel-001-mysql",
+                "permission": "cloudsql.instances.connect",
+                "granted": True,
+                "resourceAttributes": {}
+            }
+        ],
+        "resourceName": "instances/pawel-001-mysql",
+        "request": {
+            "@type": "type.googleapis.com/google.cloud.sql.v1beta4.SqlInstancesCreateEphemeralCertRequest",
+            "body": {},
+            "instance": "pawel-001-mysql",
+            "project": "dynatrace-gcp-extension"
+        },
+        "response": {
+            "kind": "sql#sslCert",
+            "@type": "type.googleapis.com/google.cloud.sql.v1beta4.SslCert"
+        }
+    },
+    "insertId": "28fvludipfi",
+    "resource": {
+        "type": "cloudsql_database",
+        "labels": {
+            "region": "europe-north1",
+            "project_id": "dynatrace-gcp-extension",
+            "database_id": "dynatrace-gcp-extension:pawel-001-mysql"
+        }
+    },
+    "timestamp": timestamp,
+    "severity": "NOTICE",
+    "logName": "projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Factivity",
+    "receiveTimestamp": "2021-06-01T13:28:03.475642010Z"
+}
+
+record4 = {
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {
+            "principalEmail": "user@dynatrace.com",
+            "principalSubject": "user:user@dynatrace.com"
+        },
+        "requestMetadata": {
+            "callerIp": "x.x.x.x",
+            "callerSuppliedUserAgent": "google-cloud-sdk gcloud/340.0.0 command/gcloud.services.enable invocation-id/1784492894a24a10a84a55e7be4d223e environment/devshell environment-version/None interactive/True from-script/True python/3.7.3 term/screen (Linux 5.4.104+),gzip(gfe)",
+            "requestAttributes": {
+                "time": "2021-06-01T10:11:14.729180Z",
+                "auth": {}
+            },
+            "destinationAttributes": {}
+        },
+        "serviceName": "serviceusage.googleapis.com",
+        "methodName": "google.longrunning.Operations.GetOperation",
+        "authorizationInfo": [
+            {
+                "resource": "projectnumbers/125992521190",
+                "permission": "serviceusage.services.enable",
+                "granted": True,
+                "resourceAttributes": {}
+            }
+        ]
+    },
+    "insertId": "1d42slpd1rhn",
+    "resource": {
+        "type": "audited_resource",
+        "labels": {
+            "service": "serviceusage.googleapis.com",
+            "project_id": "dynatrace-gcp-extension",
+            "method": "google.longrunning.Operations.GetOperation"
+        }
+    },
+    "timestamp": timestamp,
+    "severity": "NOTICE",
+    "logName": "projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Factivity",
+    "receiveTimestamp": "2021-06-01T10:11:15.496797224Z"
+}
+
+expected_output_list = [
+    {
+        ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+        ATTRIBUTE_CLOUD_REGION: 'us-central1-c',
+        ATTRIBUTE_GCP_REGION: 'us-central1-c',
+        ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+        ATTRIBUTE_GCP_RESOURCE_TYPE: 'k8s_cluster',
+        ATTRIBUTE_TIMESTAMP: timestamp,
+        ATTRIBUTE_CONTENT: json.dumps(record),
+        ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Factivity',
+        ATTRIBUTE_AUDIT_IDENTITY: 'system:vpa-recommender',
+        ATTRIBUTE_AUDIT_ACTION: 'io.k8s.core.v1.endpoints.update',
+        ATTRIBUTE_AUDIT_RESULT: 'Succeeded',
+    },
+    {
+        ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+        ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+        ATTRIBUTE_GCP_RESOURCE_TYPE: 'audited_resource',
+        ATTRIBUTE_TIMESTAMP: timestamp,
+        ATTRIBUTE_CONTENT: json.dumps(record2),
+        ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Factivity',
+        ATTRIBUTE_AUDIT_IDENTITY: 'svc-gke-dynatrace-npd@mgmt-ple-prd-83f7.iam.gserviceaccount.com',
+        ATTRIBUTE_AUDIT_ACTION: 'google.monitoring.v3.MetricService.CreateMetricDescriptor',
+        ATTRIBUTE_AUDIT_RESULT: 'Failure.PermissionDenied',
+        ATTRIBUTE_SEVERITY: "ERROR"
+    },
+    {
+        ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+        ATTRIBUTE_CLOUD_REGION: 'europe-north1',
+        ATTRIBUTE_GCP_REGION: 'europe-north1',
+        ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+        ATTRIBUTE_GCP_RESOURCE_TYPE: 'cloudsql_database',
+        ATTRIBUTE_TIMESTAMP: timestamp,
+        ATTRIBUTE_CONTENT: json.dumps(record3),
+        ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Factivity',
+        ATTRIBUTE_AUDIT_IDENTITY: 'dynatrace-gcp-extension@appspot.gserviceaccount.com',
+        ATTRIBUTE_AUDIT_ACTION: 'cloudsql.instances.connect',
+        ATTRIBUTE_AUDIT_RESULT: 'Succeeded',
+        ATTRIBUTE_SEVERITY: "NOTICE"
+    },
+    {
+        ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+        ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+        ATTRIBUTE_GCP_RESOURCE_TYPE: 'audited_resource',
+        ATTRIBUTE_TIMESTAMP: timestamp,
+        ATTRIBUTE_CONTENT: json.dumps(record4),
+        ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Factivity',
+        ATTRIBUTE_AUDIT_IDENTITY: 'user@dynatrace.com',
+        ATTRIBUTE_AUDIT_ACTION: 'google.longrunning.Operations.GetOperation',
+        ATTRIBUTE_AUDIT_RESULT: 'Succeeded',
+        ATTRIBUTE_SEVERITY: "NOTICE"
+    }
+]
+
+logs_context = LogsContext(
+    project_id_owner="",
+    dynatrace_api_key="",
+    dynatrace_url="",
+    scheduled_execution_id="",
+    sfm_queue=Queue()
+)
+
+
+def test_extraction():
+    for entry in expected_output_list:
+        actual_output = logs_processor._create_dt_log_payload(logs_context, entry[ATTRIBUTE_CONTENT])
+        assert actual_output == entry

--- a/tests/unit/extraction_rules/test_audit_data_access.py
+++ b/tests/unit/extraction_rules/test_audit_data_access.py
@@ -279,7 +279,7 @@ expected_output_list = [
         ATTRIBUTE_CONTENT: json.dumps(record4),
         ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fdata_access',
         ATTRIBUTE_AUDIT_ACTION: 'storage.objects.list',
-        ATTRIBUTE_AUDIT_RESULT: 'Failure.PermissionDenied',
+        ATTRIBUTE_AUDIT_RESULT: 'Failed.PermissionDenied',
         ATTRIBUTE_SEVERITY: "ERROR"
     },
 ]

--- a/tests/unit/extraction_rules/test_audit_data_access.py
+++ b/tests/unit/extraction_rules/test_audit_data_access.py
@@ -1,0 +1,299 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import json
+from datetime import datetime
+from queue import Queue
+from typing import NewType, Any
+
+from lib.context import LogsContext
+from lib.logs import logs_processor
+from lib.logs.metadata_engine import ATTRIBUTE_GCP_PROJECT_ID, ATTRIBUTE_GCP_RESOURCE_TYPE, ATTRIBUTE_SEVERITY, \
+    ATTRIBUTE_CLOUD_PROVIDER, ATTRIBUTE_CLOUD_REGION, ATTRIBUTE_GCP_REGION, ATTRIBUTE_CONTENT, ATTRIBUTE_TIMESTAMP, \
+    ATTRIBUTE_DT_LOGPATH, ATTRIBUTE_AUDIT_IDENTITY, ATTRIBUTE_AUDIT_ACTION, ATTRIBUTE_AUDIT_RESULT
+
+MonkeyPatchFixture = NewType("MonkeyPatchFixture", Any)
+
+timestamp = datetime.utcnow().isoformat() + "Z"
+
+record = {
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {
+            "principalEmail": "service-125992521190@container-engine-robot.iam.gserviceaccount.com"
+        },
+        "requestMetadata": {
+            "callerIp": "x.x.x.x",
+            "callerSuppliedUserAgent": "google-api-go-client/0.5,gzip(gfe)",
+            "requestAttributes": {
+                "time": "2021-06-01T14:01:29.378665Z",
+                "auth": {}
+            },
+            "destinationAttributes": {}
+        },
+        "serviceName": "compute.googleapis.com",
+        "methodName": "v1.compute.instanceGroupManagers.list",
+        "authorizationInfo": [
+            {
+                "permission": "compute.instanceGroupManagers.list",
+                "granted": True,
+                "resourceAttributes": {
+                    "service": "resourcemanager",
+                    "name": "projects/dynatrace-gcp-extension",
+                    "type": "resourcemanager.projects"
+                }
+            }
+        ],
+        "resourceName": "projects/dynatrace-gcp-extension/zones/us-central1-b/instanceGroupManagers",
+        "numResponseItems": "3",
+        "request": {
+            "@type": "type.googleapis.com/compute.instanceGroupManagers.list"
+        },
+        "resourceLocation": {
+            "currentLocations": [
+                "us-central1-b"
+            ]
+        }
+    },
+    "insertId": "uj1fsde27tew",
+    "resource": {
+        "type": "gce_instance_group_manager",
+        "labels": {
+            "instance_group_manager_id": "",
+            "instance_group_manager_name": "",
+            "project_id": "dynatrace-gcp-extension",
+            "location": "us-central1-b"
+        }
+    },
+    "timestamp": timestamp,
+    "severity": "INFO",
+    "logName": "projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fdata_access",
+    "receiveTimestamp": "2021-06-01T14:01:29.900534777Z"
+}
+
+record2 = {
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "status": {},
+        "authenticationInfo": {
+            "principalEmail": "dynatrace-gcp-service@dynatrace-gcp-extension.iam.gserviceaccount.com",
+            "serviceAccountDelegationInfo": [
+                {
+                    "firstPartyPrincipal": {
+                        "principalEmail": "service-125992521190@gcf-admin-robot.iam.gserviceaccount.com"
+                    }
+                }
+            ]
+        },
+        "requestMetadata": {
+            "callerIp": "x.x.x.x",
+            "requestAttributes": {
+                "time": "2021-06-01T14:02:21.369142Z",
+                "auth": {}
+            },
+            "destinationAttributes": {}
+        },
+        "serviceName": "cloudsql.googleapis.com",
+        "methodName": "cloudsql.instances.list",
+        "authorizationInfo": [
+            {
+                "resource": "projects/dynatrace-gcp-extension",
+                "permission": "cloudsql.instances.list",
+                "granted": True,
+                "resourceAttributes": {}
+            }
+        ],
+        "resourceName": "projects/dynatrace-gcp-extension",
+        "request": {
+            "@type": "type.googleapis.com/google.cloud.sql.v1beta4.SqlInstancesListRequest",
+            "project": "dynatrace-gcp-extension"
+        }
+    },
+    "insertId": "-najkl1daerp",
+    "resource": {
+        "type": "cloudsql_database",
+        "labels": {
+            "region": "",
+            "project_id": "dynatrace-gcp-extension",
+            "database_id": ""
+        }
+    },
+    "timestamp": timestamp,
+    "severity": "INFO",
+    "logName": "projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fdata_access",
+    "receiveTimestamp": "2021-06-01T14:02:22.357489956Z"
+}
+
+record3 = {
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "status": {},
+        "authenticationInfo": {
+            "principalEmail": "maria.swiatkowska@dynatrace.com"
+        },
+        "requestMetadata": {
+            "callerIp": "x.x.x.x",
+            "callerSuppliedUserAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36,gzip(gfe)",
+            "requestAttributes": {
+                "time": "2021-06-01T09:53:17.700228641Z",
+                "auth": {}
+            },
+            "destinationAttributes": {}
+        },
+        "serviceName": "storage.googleapis.com",
+        "methodName": "storage.buckets.list",
+        "authorizationInfo": [
+            {
+                "permission": "storage.buckets.list",
+                "granted": True,
+                "resourceAttributes": {}
+            }
+        ],
+        "resourceLocation": {
+            "currentLocations": [
+                "global"
+            ]
+        }
+    },
+    "insertId": "-jos90d74ug",
+    "resource": {
+        "type": "gcs_bucket",
+        "labels": {
+            "location": "global",
+            "bucket_name": "",
+            "project_id": "dynatrace-gcp-extension"
+        }
+    },
+    "timestamp": timestamp,
+    "severity": "INFO",
+    "logName": "projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fdata_access",
+    "receiveTimestamp": "2021-06-01T09:53:18.571784927Z"
+}
+
+record4 = {
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "status": {
+            "code": 7,
+            "message": "PERMISSION_DENIED"
+        },
+        "authenticationInfo": {},
+        "requestMetadata": {
+            "callerIp": "x.x.x.x",
+            "callerSuppliedUserAgent": "Go-http-client/1.1,gzip(gfe)",
+            "requestAttributes": {
+                "time": "2021-06-01T04:45:54.746685130Z",
+                "auth": {}
+            },
+            "destinationAttributes": {}
+        },
+        "serviceName": "storage.googleapis.com",
+        "methodName": "storage.objects.list",
+        "authorizationInfo": [
+            {
+                "resource": "projects/_/buckets/ror-test",
+                "permission": "storage.objects.list",
+                "resourceAttributes": {}
+            }
+        ],
+        "resourceName": "projects/_/buckets/ror-test",
+        "resourceLocation": {
+            "currentLocations": [
+                "us"
+            ]
+        }
+    },
+    "insertId": "jffqz2eewxni",
+    "resource": {
+        "type": "gcs_bucket",
+        "labels": {
+            "project_id": "dynatrace-gcp-extension",
+            "location": "us",
+            "bucket_name": "ror-test"
+        }
+    },
+    "timestamp": timestamp,
+    "severity": "ERROR",
+    "logName": "projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fdata_access",
+    "receiveTimestamp": "2021-06-01T04:45:55.452179480Z"
+}
+
+expected_output_list = [
+    {
+        ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+        ATTRIBUTE_CLOUD_REGION: 'us-central1-b',
+        ATTRIBUTE_GCP_REGION: 'us-central1-b',
+        ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+        ATTRIBUTE_GCP_RESOURCE_TYPE: 'gce_instance_group_manager',
+        ATTRIBUTE_TIMESTAMP: timestamp,
+        ATTRIBUTE_CONTENT: json.dumps(record),
+        ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fdata_access',
+        ATTRIBUTE_AUDIT_IDENTITY: 'service-125992521190@container-engine-robot.iam.gserviceaccount.com',
+        ATTRIBUTE_AUDIT_ACTION: 'v1.compute.instanceGroupManagers.list',
+        ATTRIBUTE_AUDIT_RESULT: 'Succeeded',
+        ATTRIBUTE_SEVERITY: "INFO"
+    },
+    {
+        ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+        ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+        ATTRIBUTE_GCP_RESOURCE_TYPE: 'cloudsql_database',
+        ATTRIBUTE_TIMESTAMP: timestamp,
+        ATTRIBUTE_CONTENT: json.dumps(record2),
+        ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fdata_access',
+        ATTRIBUTE_AUDIT_IDENTITY: 'dynatrace-gcp-service@dynatrace-gcp-extension.iam.gserviceaccount.com',
+        ATTRIBUTE_AUDIT_ACTION: 'cloudsql.instances.list',
+        ATTRIBUTE_AUDIT_RESULT: 'Succeeded',
+        ATTRIBUTE_SEVERITY: "INFO"
+    },
+    {
+        ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+        ATTRIBUTE_CLOUD_REGION: 'global',
+        ATTRIBUTE_GCP_REGION: 'global',
+        ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+        ATTRIBUTE_GCP_RESOURCE_TYPE: 'gcs_bucket',
+        ATTRIBUTE_TIMESTAMP: timestamp,
+        ATTRIBUTE_CONTENT: json.dumps(record3),
+        ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fdata_access',
+        ATTRIBUTE_AUDIT_IDENTITY: 'maria.swiatkowska@dynatrace.com',
+        ATTRIBUTE_AUDIT_ACTION: 'storage.buckets.list',
+        ATTRIBUTE_AUDIT_RESULT: 'Succeeded',
+        ATTRIBUTE_SEVERITY: "INFO"
+    },
+    {
+        ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+        ATTRIBUTE_CLOUD_REGION: 'us',
+        ATTRIBUTE_GCP_REGION: 'us',
+        ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+        ATTRIBUTE_GCP_RESOURCE_TYPE: 'gcs_bucket',
+        ATTRIBUTE_TIMESTAMP: timestamp,
+        ATTRIBUTE_CONTENT: json.dumps(record4),
+        ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fdata_access',
+        ATTRIBUTE_AUDIT_ACTION: 'storage.objects.list',
+        ATTRIBUTE_AUDIT_RESULT: 'Failure.PermissionDenied',
+        ATTRIBUTE_SEVERITY: "ERROR"
+    },
+]
+
+logs_context = LogsContext(
+    project_id_owner="",
+    dynatrace_api_key="",
+    dynatrace_url="",
+    scheduled_execution_id="",
+    sfm_queue=Queue()
+)
+
+
+def test_extraction():
+    for entry in expected_output_list:
+        actual_output = logs_processor._create_dt_log_payload(logs_context, entry[ATTRIBUTE_CONTENT])
+        assert actual_output == entry

--- a/tests/unit/extraction_rules/test_audit_policy.py
+++ b/tests/unit/extraction_rules/test_audit_policy.py
@@ -89,7 +89,7 @@ expected_output_list = [
         ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fpolicy',
         ATTRIBUTE_AUDIT_IDENTITY: 'someone@google.com',
         ATTRIBUTE_AUDIT_ACTION: 'google.storage.NoBillingOk',
-        ATTRIBUTE_AUDIT_RESULT: 'Failure.PermissionDenied',
+        ATTRIBUTE_AUDIT_RESULT: 'Failed.PermissionDenied',
         ATTRIBUTE_SEVERITY: 'ERROR',
     }
 ]

--- a/tests/unit/extraction_rules/test_audit_policy.py
+++ b/tests/unit/extraction_rules/test_audit_policy.py
@@ -1,0 +1,109 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import json
+from datetime import datetime
+from queue import Queue
+from typing import NewType, Any
+
+from lib.context import LogsContext
+from lib.logs import logs_processor
+from lib.logs.metadata_engine import ATTRIBUTE_GCP_PROJECT_ID, ATTRIBUTE_GCP_RESOURCE_TYPE, ATTRIBUTE_SEVERITY, \
+    ATTRIBUTE_CLOUD_PROVIDER, ATTRIBUTE_CLOUD_REGION, ATTRIBUTE_GCP_REGION, ATTRIBUTE_CONTENT, ATTRIBUTE_TIMESTAMP, \
+    ATTRIBUTE_DT_LOGPATH, ATTRIBUTE_AUDIT_IDENTITY, ATTRIBUTE_AUDIT_ACTION, ATTRIBUTE_AUDIT_RESULT
+
+MonkeyPatchFixture = NewType("MonkeyPatchFixture", Any)
+
+timestamp = datetime.utcnow().isoformat() + "Z"
+
+# From https://cloud.google.com/vpc-service-controls/docs/troubleshooting
+record = {
+    "insertId": "222lvajc6f7",
+    "logName": "projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fpolicy",
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {
+            "principalEmail": "someone@google.com"
+        },
+        "metadata": {
+            "@type": "type.googleapis.com/google.cloud.audit.VpcServiceControlAuditMetadata",
+            "resourceNames": [
+                "projects/_"
+            ],
+            "violationReason": "NO_MATCHING_ACCESS_LEVEL"
+        },
+        "methodName": "google.storage.NoBillingOk",
+        "requestMetadata": {
+            "callerIp": "x.x.x.x",
+            "destinationAttributes": {},
+            "requestAttributes": {}
+        },
+        "resourceName": "projects/690885588241",
+        "serviceName": "storage.googleapis.com",
+        "status": {
+            "code": 7,
+            "details": [
+                {
+                    "@type": "type.googleapis.com/google.rpc.PreconditionFailure",
+                    "violations": [
+                        {
+                            "type": "VPC_SERVICE_CONTROLS"
+                        }
+                    ]
+                }
+            ],
+            "message": "Request is prohibited by organization's policy"
+        }
+    },
+    "receiveTimestamp": "2018-11-27T21:40:43.823209571Z",
+    "resource": {
+        "labels": {
+            "method": "google.storage.NoBillingOk",
+            "project_id": "dynatrace-gcp-extension",
+            "service": "storage.googleapis.com"
+        },
+        "type": "audited_resource"
+    },
+    "severity": "ERROR",
+    "timestamp": timestamp
+}
+
+
+expected_output_list = [
+    {
+        ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+        ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+        ATTRIBUTE_GCP_RESOURCE_TYPE: 'audited_resource',
+        ATTRIBUTE_TIMESTAMP: timestamp,
+        ATTRIBUTE_CONTENT: json.dumps(record),
+        ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fpolicy',
+        ATTRIBUTE_AUDIT_IDENTITY: 'someone@google.com',
+        ATTRIBUTE_AUDIT_ACTION: 'google.storage.NoBillingOk',
+        ATTRIBUTE_AUDIT_RESULT: 'Failure.PermissionDenied',
+        ATTRIBUTE_SEVERITY: 'ERROR',
+    }
+]
+
+logs_context = LogsContext(
+    project_id_owner="",
+    dynatrace_api_key="",
+    dynatrace_url="",
+    scheduled_execution_id="",
+    sfm_queue=Queue()
+)
+
+
+def test_extraction():
+    for entry in expected_output_list:
+        actual_output = logs_processor._create_dt_log_payload(logs_context, entry[ATTRIBUTE_CONTENT])
+        assert actual_output == entry

--- a/tests/unit/extraction_rules/test_audit_system_event.py
+++ b/tests/unit/extraction_rules/test_audit_system_event.py
@@ -1,0 +1,231 @@
+#     Copyright 2020 Dynatrace LLC
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import json
+from datetime import datetime
+from queue import Queue
+from typing import NewType, Any
+
+from lib.context import LogsContext
+from lib.logs import logs_processor
+from lib.logs.metadata_engine import ATTRIBUTE_GCP_PROJECT_ID, ATTRIBUTE_GCP_RESOURCE_TYPE, ATTRIBUTE_SEVERITY, \
+    ATTRIBUTE_CLOUD_PROVIDER, ATTRIBUTE_CLOUD_REGION, ATTRIBUTE_GCP_REGION, ATTRIBUTE_CONTENT, ATTRIBUTE_TIMESTAMP, \
+    ATTRIBUTE_DT_LOGPATH, ATTRIBUTE_AUDIT_IDENTITY, ATTRIBUTE_AUDIT_ACTION, ATTRIBUTE_AUDIT_RESULT
+
+MonkeyPatchFixture = NewType("MonkeyPatchFixture", Any)
+
+timestamp = datetime.utcnow().isoformat() + "Z"
+
+record = {
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "status": {
+            "message": "Instance migrated during Compute Engine maintenance."
+        },
+        "authenticationInfo": {
+            "principalEmail": "system@google.com"
+        },
+        "serviceName": "compute.googleapis.com",
+        "methodName": "compute.instances.migrateOnHostMaintenance",
+        "resourceName": "projects/dynatrace-gcp-extension/zones/us-central1-c/instances/gke-gke-helm-ms-default-pool-56e1a146-z9hp",
+        "request": {
+            "@type": "type.googleapis.com/compute.instances.migrateOnHostMaintenance"
+        }
+    },
+    "insertId": "-v2jb93e1idm2",
+    "resource": {
+        "type": "gce_instance",
+        "labels": {
+            "project_id": "dynatrace-gcp-extension",
+            "zone": "us-central1-c",
+            "instance_id": "783056456320399836"
+        }
+    },
+    "timestamp": timestamp,
+    "severity": "INFO",
+    "logName": "projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fsystem_event",
+    "operation": {
+        "id": "systemevent-1622206140000-5c3634cba2700-a1c9a436-380ea389",
+        "producer": "compute.instances.migrateOnHostMaintenance",
+        "first": True,
+        "last": True
+    },
+    "receiveTimestamp": "2021-05-28T12:49:35.760642486Z"
+}
+
+record2 = {
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "status": {
+            "message": "Ready condition status changed to True for Service user-test."
+        },
+        "serviceName": "run.googleapis.com",
+        "resourceName": "namespaces/dynatrace-gcp-extension/services/user-test",
+        "response": {
+            "metadata": {
+                "name": "user-test",
+                "namespace": "125992521190",
+                "selfLink": "/apis/serving.knative.dev/v1/namespaces/125992521190/services/user-test",
+                "uid": "31507df8-baf4-4b1d-9fb3-6951da0cfffb",
+                "resourceVersion": "AAXDIkEBm98",
+                "generation": 1,
+                "creationTimestamp": "2021-05-25T07:12:42.946813Z",
+                "labels": {
+                    "cloud.googleapis.com/location": "us-central1"
+                },
+                "annotations": {
+                    "run.googleapis.com/client-name": "cloud-console",
+                    "serving.knative.dev/creator": "michal.franczak@dynatrace.com",
+                    "serving.knative.dev/lastModifier": "michal.franczak@dynatrace.com",
+                    "client.knative.dev/user-image": "us-docker.pkg.dev/cloudrun/container/hello",
+                    "run.googleapis.com/ingress": "all",
+                    "run.googleapis.com/ingress-status": "all"
+                }
+            },
+            "apiVersion": "serving.knative.dev/v1",
+            "kind": "Service",
+            "spec": {
+                "template": {
+                    "metadata": {
+                        "name": "user-test-00001-box",
+                        "annotations": {
+                            "run.googleapis.com/client-name": "cloud-console",
+                            "autoscaling.knative.dev/maxScale": "100",
+                            "run.googleapis.com/sandbox": "gvisor"
+                        }
+                    },
+                    "spec": {
+                        "containerConcurrency": 80,
+                        "timeoutSeconds": 300,
+                        "serviceAccountName": "125992521190-compute@developer.gserviceaccount.com",
+                        "containers": [
+                            {
+                                "image": "us-docker.pkg.dev/cloudrun/container/hello",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "1000m",
+                                        "memory": "512Mi"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "traffic": [
+                    {
+                        "percent": 100,
+                        "latestRevision": True
+                    }
+                ]
+            },
+            "status": {
+                "observedGeneration": 1,
+                "conditions": [
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastTransitionTime": "2021-05-25T07:12:50.482143Z"
+                    },
+                    {
+                        "type": "ConfigurationsReady",
+                        "status": "True",
+                        "lastTransitionTime": "2021-05-25T07:12:49.747245Z"
+                    },
+                    {
+                        "type": "RoutesReady",
+                        "status": "True",
+                        "lastTransitionTime": "2021-05-25T07:12:50.482143Z"
+                    }
+                ],
+                "latestReadyRevisionName": "user-test-00001-box",
+                "latestCreatedRevisionName": "user-test-00001-box",
+                "traffic": [
+                    {
+                        "revisionName": "user-test-00001-box",
+                        "percent": 100,
+                        "latestRevision": True
+                    }
+                ],
+                "url": "https://user-test-znf4tqelca-uc.a.run.app",
+                "address": {
+                    "url": "https://user-test-znf4tqelca-uc.a.run.app"
+                }
+            },
+            "@type": "type.googleapis.com/google.cloud.run.v1.Service"
+        }
+    },
+    "insertId": "-xujmfncgd0",
+    "resource": {
+        "type": "cloud_run_revision",
+        "labels": {
+            "location": "us-central1",
+            "revision_name": "",
+            "service_name": "user-test",
+            "project_id": "dynatrace-gcp-extension",
+            "configuration_name": ""
+        }
+    },
+    "timestamp": timestamp,
+    "severity": "INFO",
+    "logName": "projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fsystem_event",
+    "receiveTimestamp": "2021-05-25T07:12:51.131933174Z"
+}
+
+expected_output_list = [
+    {
+        ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+        ATTRIBUTE_CLOUD_REGION: 'us-central1-c',
+        ATTRIBUTE_GCP_REGION: 'us-central1-c',
+        ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+        ATTRIBUTE_GCP_RESOURCE_TYPE: 'gce_instance',
+        ATTRIBUTE_TIMESTAMP: timestamp,
+        ATTRIBUTE_CONTENT: json.dumps(record),
+        ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fsystem_event',
+        ATTRIBUTE_AUDIT_IDENTITY: 'system@google.com',
+        ATTRIBUTE_AUDIT_ACTION: 'compute.instances.migrateOnHostMaintenance',
+        ATTRIBUTE_AUDIT_RESULT: 'Succeeded',
+        ATTRIBUTE_SEVERITY: "INFO",
+        'gcp.instance.id': '783056456320399836'
+    },
+    {
+        ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
+        ATTRIBUTE_CLOUD_REGION: 'us-central1',
+        ATTRIBUTE_GCP_REGION: 'us-central1',
+        ATTRIBUTE_GCP_PROJECT_ID: 'dynatrace-gcp-extension',
+        ATTRIBUTE_GCP_RESOURCE_TYPE: 'cloud_run_revision',
+        ATTRIBUTE_TIMESTAMP: timestamp,
+        ATTRIBUTE_CONTENT: json.dumps(record2),
+        ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Fsystem_event',
+        ATTRIBUTE_AUDIT_RESULT: 'Succeeded',
+        ATTRIBUTE_SEVERITY: "INFO"
+    },
+]
+
+logs_context = LogsContext(
+    project_id_owner="",
+    dynatrace_api_key="",
+    dynatrace_url="",
+    scheduled_execution_id="",
+    sfm_queue=Queue()
+)
+
+
+def test_extraction():
+    for entry in expected_output_list:
+        actual_output = logs_processor._create_dt_log_payload(logs_context, entry[ATTRIBUTE_CONTENT])
+        assert actual_output == entry

--- a/tests/unit/extraction_rules/test_cloud_function.py
+++ b/tests/unit/extraction_rules/test_cloud_function.py
@@ -19,7 +19,8 @@ from lib.context import LogsContext
 from lib.logs.logs_processor import _create_dt_log_payload
 from lib.logs.metadata_engine import ATTRIBUTE_GCP_PROJECT_ID, ATTRIBUTE_GCP_RESOURCE_TYPE, ATTRIBUTE_SEVERITY, \
     ATTRIBUTE_CLOUD_PROVIDER, ATTRIBUTE_CLOUD_REGION, ATTRIBUTE_GCP_REGION, ATTRIBUTE_GCP_INSTANCE_NAME, \
-    ATTRIBUTE_CONTENT, ATTRIBUTE_TIMESTAMP, ATTRIBUTE_DT_LOGPATH
+    ATTRIBUTE_CONTENT, ATTRIBUTE_TIMESTAMP, ATTRIBUTE_DT_LOGPATH, ATTRIBUTE_AUDIT_ACTION, ATTRIBUTE_AUDIT_IDENTITY, \
+    ATTRIBUTE_AUDIT_RESULT
 
 timestamp = datetime.utcnow().isoformat() + "Z"
 
@@ -137,6 +138,9 @@ error_proto_record = {
 }
 
 error_proto_record_expected_output = {
+    ATTRIBUTE_AUDIT_ACTION: 'google.cloud.functions.v1.CloudFunctionsService.UpdateFunction',
+    ATTRIBUTE_AUDIT_IDENTITY: 'xxxxx@dynatrace.com',
+    ATTRIBUTE_AUDIT_RESULT: 'Failure.InvalidArgument',
     ATTRIBUTE_SEVERITY: 'ERROR',
     ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
     ATTRIBUTE_CLOUD_REGION: 'europe-central2',
@@ -145,7 +149,7 @@ error_proto_record_expected_output = {
     ATTRIBUTE_GCP_RESOURCE_TYPE: 'cloud_function',
     ATTRIBUTE_GCP_INSTANCE_NAME: 'dynatrace-gcp-function',
     ATTRIBUTE_TIMESTAMP: timestamp,
-    ATTRIBUTE_CONTENT: "Build failed: build succeeded but did not produce the class \"com.example.Example\" specified as the function target: Error: class not found: com.example.Example; Error ID: 108a9950",
+    ATTRIBUTE_CONTENT: json.dumps(error_proto_record),
     ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudaudit.googleapis.com%2Factivity',
     'faas.name': 'dynatrace-gcp-function'
 }

--- a/tests/unit/extraction_rules/test_cloud_function.py
+++ b/tests/unit/extraction_rules/test_cloud_function.py
@@ -140,7 +140,7 @@ error_proto_record = {
 error_proto_record_expected_output = {
     ATTRIBUTE_AUDIT_ACTION: 'google.cloud.functions.v1.CloudFunctionsService.UpdateFunction',
     ATTRIBUTE_AUDIT_IDENTITY: 'xxxxx@dynatrace.com',
-    ATTRIBUTE_AUDIT_RESULT: 'Failure.InvalidArgument',
+    ATTRIBUTE_AUDIT_RESULT: 'Failed.InvalidArgument',
     ATTRIBUTE_SEVERITY: 'ERROR',
     ATTRIBUTE_CLOUD_PROVIDER: 'gcp',
     ATTRIBUTE_CLOUD_REGION: 'europe-central2',


### PR DESCRIPTION
Minor change to metadata engine itself - discussion with @pawelsiwek lead to conclusion we should apply `audit_logs` rules to logs matched with other rules, and apply them last, to overwrite any attributes introduced by other rules.