### PR TITLE
APM-306494: Docker image param for Helm chart

### DIFF
--- a/k8s/helm-chart/dynatrace-gcp-function/templates/template.yml
+++ b/k8s/helm-chart/dynatrace-gcp-function/templates/template.yml
@@ -83,7 +83,7 @@ spec:
       {{- end }}
       containers:
       {{- if or (eq .Values.deploymentType "metrics") (eq .Values.deploymentType "all") }}
-      - image: dynatrace/dynatrace-gcp-function
+      - image: {{ .Values.dockerImage | quote }}
         name: dynatrace-gcp-function-metrics      
         imagePullPolicy: Always
         env:
@@ -177,7 +177,7 @@ spec:
           initialDelaySeconds: 10
       {{- end }}
       {{- if or (eq .Values.deploymentType "logs") (eq .Values.deploymentType "all") }}
-      - image: dynatrace/dynatrace-gcp-function
+      - image: {{ .Values.dockerImage | quote }}
         name: dynatrace-gcp-function-logs
         imagePullPolicy: Always
         env:

--- a/k8s/helm-chart/dynatrace-gcp-function/values.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-function/values.yaml
@@ -17,6 +17,9 @@ dynatraceAccessKey: ""
 # Send custom metrics to GCP to diagnose quickly if your dynatrace-gcp-function processes and sends metrics/logs to Dynatrace properly.
 # Allowed values: "true"/"yes", "false"/"no"
 selfMonitoringEnabled: "false"
+# Dynatrace GCP function docker image. Using default value is advised,
+# but can be changed if there is a need to use customized image or specific, tagged version
+dockerImage: "dynatrace/dynatrace-gcp-function"
 
 
 # METRICS VALUES


### PR DESCRIPTION
Not introducing this value as `deploy-helm.sh` parameter, as with APM-306738 user will edit `values.yaml` directly