### PR TITLE
Stop adding multiple values with indexes for entity dimensions

### DIFF
--- a/src/lib/entities/extractors/cloud_function.py
+++ b/src/lib/entities/extractors/cloud_function.py
@@ -72,13 +72,13 @@ def _cloud_function_resp_to_monitored_entities(page: Dict[Text, Any], svc_def: G
             id=create_entity_id(cd, svc_def),
             display_name=_extract_label(cd.get("name", ""), 3),
             group=svc_def.technology_name,
-            ip_addresses=frozenset(),
-            listen_ports=frozenset(),
+            ip_addresses=[],
+            listen_ports=[],
             favicon_url="no-gcp-icon-available",
             dtype=svc_def.technology_name,
             properties=_get_properties(cd),
-            tags=frozenset(),
-            dns_names=frozenset()
+            tags=[],
+            dns_names=[]
         ) for cd in page.get("functions", [])
     ]
 

--- a/src/lib/entities/extractors/cloud_sql.py
+++ b/src/lib/entities/extractors/cloud_sql.py
@@ -49,13 +49,13 @@ def _cloud_sql_resp_to_monitored_entities(page: Dict[Text, Any], svc_def: GCPSer
             id=create_entity_id(cd, svc_def),
             display_name=cd.get("name", "N/A"),
             group=svc_def.technology_name,
-            ip_addresses=frozenset(x["ipAddress"] for x in cd.get("ipAddresses", [])),
-            listen_ports=frozenset(),
+            ip_addresses=[x["ipAddress"] for x in cd.get("ipAddresses", [])],
+            listen_ports=[],
             favicon_url="no-gcp-icon-available",
             dtype=svc_def.technology_name,
             properties=_get_properties(cd),
-            tags=frozenset(),
-            dns_names=frozenset()
+            tags=[],
+            dns_names=[]
         ) for cd in page.get("items", [])
     ]
 

--- a/src/lib/entities/extractors/filestore_instance.py
+++ b/src/lib/entities/extractors/filestore_instance.py
@@ -70,17 +70,13 @@ def _filestore_instance_resp_to_monitored_entities(page: Dict[Text, Any], svc_de
             id=create_entity_id(cd, svc_def),
             display_name=_extract_label(cd.get("name", ""), 3),
             group=svc_def.technology_name,
-            ip_addresses=frozenset(
-                itertools.chain.from_iterable([
-                    x.get("ipAddresses", []) for x in cd.get("networks", [])
-                ])
-            ),
-            listen_ports=frozenset(),
+            ip_addresses=[x.get("ipAddresses", []) for x in cd.get("networks", [])],
+            listen_ports=[],
             favicon_url="no-gcp-icon-available",
             dtype=svc_def.technology_name,
             properties=_get_properties(cd),
-            tags=frozenset(),
-            dns_names=frozenset()
+            tags=[],
+            dns_names=[]
         ) for cd in page.get("instances", [])
     ]
 

--- a/src/lib/entities/extractors/gce_instance.py
+++ b/src/lib/entities/extractors/gce_instance.py
@@ -98,13 +98,13 @@ def _cloud_function_resp_to_monitored_entities(page: Dict[Text, Any], svc_def: G
             id=get_func_create_entity_id(mappings)(cd, svc_def),
             display_name=cd.get("name", ""),
             group=svc_def.technology_name,
-            ip_addresses=frozenset(ips),
-            listen_ports=frozenset(),
+            ip_addresses=ips,
+            listen_ports=[],
             favicon_url="no-gcp-icon-available",
             dtype=svc_def.technology_name,
             properties=_get_properties(cd),
-            tags=frozenset(tags),
-            dns_names=frozenset()
+            tags=[],
+            dns_names=[]
         ))
 
     return entities

--- a/src/lib/entities/extractors/pubsub_subscription.py
+++ b/src/lib/entities/extractors/pubsub_subscription.py
@@ -67,13 +67,13 @@ def _cloud_function_resp_to_monitored_entities(page: Dict[Text, Any], svc_def: G
             id=create_entity_id(cd, svc_def),
             display_name=_extract_label(cd.get("name", ""), 2),
             group=svc_def.technology_name,
-            ip_addresses=frozenset(),
-            listen_ports=frozenset(),
+            ip_addresses=[],
+            listen_ports=[],
             favicon_url="no-gcp-icon-available",
             dtype=svc_def.technology_name,
             properties=_get_properties(cd),
-            tags=frozenset(),
-            dns_names=frozenset()
+            tags=[],
+            dns_names=[]
         ) for cd in page.get("subscriptions", [])
     ]
 

--- a/src/lib/entities/model.py
+++ b/src/lib/entities/model.py
@@ -16,7 +16,7 @@
 
 from dataclasses import dataclass
 from json import dumps
-from typing import Callable, FrozenSet, Iterable, NamedTuple, Text
+from typing import Callable, FrozenSet, Iterable, NamedTuple, Text, List
 
 from lib.context import MetricsContext
 from lib.metrics import GCPService
@@ -36,13 +36,13 @@ class Entity:  # pylint: disable=R0902
     id: Text
     display_name: Text
     group: Text
-    ip_addresses: FrozenSet[str]
-    listen_ports: FrozenSet[str]
+    ip_addresses: List[str]
+    listen_ports: List[str]
     favicon_url: Text
     dtype: Text
     properties: Iterable[CdProperty]
-    tags: FrozenSet[str]
-    dns_names: FrozenSet[str]
+    tags: List[str]
+    dns_names: List[str]
 
 
 ExtractEntitesFunc = Callable[[MetricsContext, str, GCPService], Iterable[Entity]]

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -250,14 +250,20 @@ def flatten_and_enrich_metric_results(
         for ingest_line in ingest_lines:
             entity = entity_id_map.get(ingest_line.entity_id, None)
             if entity:
-                for index, dns_name in enumerate(entity.dns_names):
-                    dim_name = "dns_name" if index == 0 else f"dns_name.{index}"
-                    dimension_value = create_dimension(name=entity_dimension_prefix + dim_name, value=dns_name, context=context)
+                if entity.dns_names:
+                    dimension_value = create_dimension(
+                        name=entity_dimension_prefix + "dns_name",
+                        value=entity.dns_names[0],
+                        context=context
+                    )
                     ingest_line.dimension_values.append(dimension_value)
 
-                for index, ip_address in enumerate(entity.ip_addresses):
-                    dim_name = "ip_address" if index == 0 else f"ip_address.{index}"
-                    dimension_value = create_dimension(name=entity_dimension_prefix + dim_name, value=ip_address, context=context)
+                if entity.ip_addresses:
+                    dimension_value = create_dimension(
+                        name=entity_dimension_prefix + "ip_address",
+                        value=entity.ip_addresses[0],
+                        context=context
+                    )
                     ingest_line.dimension_values.append(dimension_value)
 
                 for cd_property in entity.properties:

--- a/src/main.py
+++ b/src/main.py
@@ -238,6 +238,11 @@ def build_entity_id_map(fetch_topology_results: List[List[Entity]]) -> Dict[str,
     result = {}
     for result_set in fetch_topology_results:
         for entity in result_set:
+            # Ensure order of entries to avoid "flipping" when choosing the first one for dimension value
+            entity.dns_names.sort()
+            entity.ip_addresses.sort()
+            entity.tags.sort()
+            entity.listen_ports.sort()
             result[entity.id] = entity
     return result
 

--- a/tests/e2e/deployment-test.sh
+++ b/tests/e2e/deployment-test.sh
@@ -113,7 +113,7 @@ echo -n "Verifying deployment result"
 METRICS_CONTAINER_STATE=0
 LOGS_CONTAINER_STATE=0
 
-for i in {1..30}
+for i in {1..60}
 do
   if [[ $DEPLOYMENT_TYPE == all ]] || [[ $DEPLOYMENT_TYPE == metrics ]]; then
     check_container_state "dynatrace-gcp-function-metrics"

--- a/tests/unit/metrics_ingest_test.py
+++ b/tests/unit/metrics_ingest_test.py
@@ -2,6 +2,7 @@ import aiohttp
 
 from lib.entities.model import CdProperty
 from lib.metric_ingest import *
+from main import build_entity_id_map
 
 
 def test_create_dimension_correct_values():
@@ -27,9 +28,9 @@ def test_create_dimension_too_long_dimension():
 def test_flatten_and_enrich_metric_results_all_additional_dimensions():
     context_mock = MetricsContext(aiohttp.ClientSession(), aiohttp.ClientSession(), "", "", datetime.utcnow(), 0, "", "", False, False, None)
     metric_results = [[IngestLine("entity_id", "m1", "count", 1, 10000, [])]]
-    entity_id_map = {"entity_id": Entity("entity_id", "", "", ip_addresses=frozenset(["0.0.0.0"]), listen_ports=frozenset([]),
+    entity_id_map = build_entity_id_map([[Entity("entity_id", "", "", ip_addresses=["1.1.1.1", "0.0.0.0"], listen_ports=[],
                                          favicon_url="", dtype="", properties=[CdProperty("Example property", "example_value")],
-                                         tags=frozenset([]), dns_names=frozenset(["dns.name"]))}
+                                         tags=[], dns_names=["other.dns.name", "dns.name"])]])
 
     lines = flatten_and_enrich_metric_results(context=context_mock, fetch_metric_results=metric_results, entity_id_map=entity_id_map)
 


### PR DESCRIPTION
After discussion with @pawelsiwek and @sq2gxo we came to conclusion that we should entirely drop adding "indexed" dimension values for dimensions extracted from entities.

Additionally, I've doubled number of helm deployment status check periods in E2E test, as it caused the test to be flaky.