### PR TITLE
APM-318373 fix parsing yq bug

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -343,7 +343,7 @@ if [[ "${IMPORT_DASHBOARDS,,}" =~ ^(yes|true)$ ]] ; then
       warn "Found existing Google dashboards in [${DYNATRACE_URL}] tenant:\n$EXISTING_DASHBOARDS"
   fi
 
-  for DASHBOARD_PATH in $(get_ext_files 'dashboards[*].dashboard')
+  for DASHBOARD_PATH in $(get_ext_files 'dashboards[].dashboard')
   do
     DASHBOARD_JSON=$(cat "./$DASHBOARD_PATH")
     DASHBOARD_NAME=$(jq -r .dashboardMetadata.name < "./$DASHBOARD_PATH")
@@ -377,7 +377,7 @@ if [[ "${IMPORT_ALERTS,,}" =~ ^(yes|true)$ ]]; then
       warn "Found existing Google alerts in [${DYNATRACE_URL}] tenant:\n$EXISTING_ALERTS"
   fi
 
-  for ALERT_PATH in $(get_ext_files 'alerts[*].path')
+  for ALERT_PATH in $(get_ext_files 'alerts[].path')
   do
     ALERT_JSON=$(cat "./$ALERT_PATH")
     ALERT_ID=$(jq -r .id < "./$ALERT_PATH")


### PR DESCRIPTION
after fix
```
...
- create self monitoring dashboard
Dashboard already exists, skipping
- Dashboard [Google Cloud APIs] already exists on cluster, skipping
- Dashboard [Google Cloud Function] already exists on cluster, skipping
- Dashboard [Google Cloud SQL] already exists on cluster, skipping
- Dashboard [Google Cloud Datastore] already exists on cluster, skipping
- Dashboard [Google Cloud Storage] already exists on cluster, skipping
- Dashboard [Google Cloud HTTPs Load Balancing] already exists on cluster, skipping
- Dashboard [Google Kubernetes Engine] already exists on cluster, skipping
- Dashboard [Google Cloud Pub/Sub] already exists on cluster, skipping
- Dashboard [Google Cloud Pub/Sub] already exists on cluster, skipping
- Dashboard [Google Cloud TCP Load Balancing] already exists on cluster, skipping
- Importing alerts
- Alert [Cloud SQL Database CPU utilization [GCP]] already exists on cluster, skipping
- Alert [Google Pub/Sub Lite Topic Partition publish quota utilization ratio [GCP]] already exists on cluster, skipping
- Alert [Google Pub/Sub Lite Topic Partition subscribe quota utilization ratio [GCP]] already exists on cluster, skipping
...
```