### PR TITLE
Bugfix/apm 318021 sending whole log message in content

### DIFF
--- a/src/config_logs/cloud_function.json
+++ b/src/config_logs/cloud_function.json
@@ -22,6 +22,10 @@
         {
           "key": "gcp.instance.name",
           "pattern": "resource.labels.function_name"
+        },
+        {
+          "key": "content",
+          "pattern": "@"
         }
       ]
     }

--- a/src/config_logs/cloud_function.json
+++ b/src/config_logs/cloud_function.json
@@ -20,10 +20,6 @@
           "pattern": "resource.labels.function_name"
         },
         {
-          "key": "content",
-          "pattern": "textPayload || jsonPayload.message || jsonPayload.statusDetails || jsonPayload || protoPayload.status.message|| protoPayload"
-        },
-        {
           "key": "gcp.instance.name",
           "pattern": "resource.labels.function_name"
         }

--- a/src/config_logs/cloud_sql.json
+++ b/src/config_logs/cloud_sql.json
@@ -14,6 +14,10 @@
         {
           "key": "gcp.instance.id",
           "pattern": "resource.labels.database_id"
+        },
+        {
+          "key": "content",
+          "pattern": "@"
         }
       ]
     }

--- a/src/config_logs/cloud_sql.json
+++ b/src/config_logs/cloud_sql.json
@@ -12,10 +12,6 @@
       ],
       "attributes": [
         {
-          "key": "content",
-          "pattern": "textPayload || protoPayload.status.message|| protoPayload || jsonPayload.message || jsonPayload.statusDetails || jsonPayload"
-        },
-        {
           "key": "gcp.instance.id",
           "pattern": "resource.labels.database_id"
         }

--- a/src/config_logs/common.json
+++ b/src/config_logs/common.json
@@ -40,10 +40,6 @@
         {
           "key": "log.source",
           "pattern": "logName"
-        },
-        {
-          "key": "content",
-          "pattern": "@"
         }
       ]
     }

--- a/src/config_logs/common.json
+++ b/src/config_logs/common.json
@@ -40,6 +40,10 @@
         {
           "key": "log.source",
           "pattern": "logName"
+        },
+        {
+          "key": "content",
+          "pattern": "@"
         }
       ]
     }

--- a/src/config_logs/k8s_container.json
+++ b/src/config_logs/k8s_container.json
@@ -28,10 +28,6 @@
           "pattern": "resource.labels.pod_name"
         },
         {
-          "key": "content",
-          "pattern": "textPayload"
-        },
-        {
           "key": "gcp.instance.name",
           "pattern": "resource.labels.container_name"
         }

--- a/src/config_logs/k8s_container.json
+++ b/src/config_logs/k8s_container.json
@@ -30,6 +30,10 @@
         {
           "key": "gcp.instance.name",
           "pattern": "resource.labels.container_name"
+        },
+        {
+          "key": "content",
+          "pattern": "@"
         }
       ]
     }

--- a/tests/unit/extraction_rules/test_cloud_function.py
+++ b/tests/unit/extraction_rules/test_cloud_function.py
@@ -53,7 +53,7 @@ debug_text_record_expected_output = {
     ATTRIBUTE_GCP_RESOURCE_TYPE: 'cloud_function',
     ATTRIBUTE_GCP_INSTANCE_NAME: 'dynatrace-gcp-function',
     ATTRIBUTE_TIMESTAMP: timestamp,
-    ATTRIBUTE_CONTENT: "Function execution started",
+    ATTRIBUTE_CONTENT: json.dumps(debug_text_record),
     ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudfunctions.googleapis.com%2Fcloud-functions',
     'faas.id': 'j22o0ucdhpop',
     'faas.name': 'dynatrace-gcp-function'
@@ -97,7 +97,7 @@ notice_json_record_expected_output = {
     ATTRIBUTE_GCP_RESOURCE_TYPE: 'cloud_function',
     ATTRIBUTE_GCP_INSTANCE_NAME: 'dynatrace-gcp-function',
     ATTRIBUTE_TIMESTAMP: timestamp,
-    ATTRIBUTE_CONTENT: "Error detected in dynatrace-logs-ingest",
+    ATTRIBUTE_CONTENT: json.dumps(notice_json_record),
     ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/clouderrorreporting.googleapis.com%2Finsights',
     'faas.name': 'dynatrace-gcp-function'
 }

--- a/tests/unit/extraction_rules/test_cloud_sql.py
+++ b/tests/unit/extraction_rules/test_cloud_sql.py
@@ -45,7 +45,7 @@ expected_output = {
     ATTRIBUTE_GCP_RESOURCE_TYPE: 'cloudsql_database',
     ATTRIBUTE_GCP_INSTANCE_ID: 'dynatrace-gcp-extension:test-001-mysql',
     ATTRIBUTE_TIMESTAMP: timestamp,
-    ATTRIBUTE_CONTENT: 'ON DUPLICATE KEY UPDATE master_time=UTC_TIMESTAMP(6);',
+    ATTRIBUTE_CONTENT: json.dumps(log_record),
     ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/cloudsql.googleapis.com%2Fmysql-slow.log',
     ATTRIBUTE_SEVERITY: "INFO"
 }

--- a/tests/unit/extraction_rules/test_k8s_container.py
+++ b/tests/unit/extraction_rules/test_k8s_container.py
@@ -58,7 +58,7 @@ expected_output = {
     ATTRIBUTE_GCP_RESOURCE_TYPE: 'k8s_container',
     ATTRIBUTE_GCP_INSTANCE_NAME: 'test-app-api',
     ATTRIBUTE_TIMESTAMP: timestamp,
-    ATTRIBUTE_CONTENT: '2021-03-17 19:58:17.890 DEBUG 1 --- [io-8080-exec-18] o.s.web.servlet.DispatcherServlet        : Completed 200 OK\n',
+    ATTRIBUTE_CONTENT: json.dumps(log_record),
     ATTRIBUTE_DT_LOGPATH: 'projects/dynatrace-gcp-extension/logs/stdout',
     'container.name': 'test-app-api',
     'k8s.cluster.name': 'test-cluster',


### PR DESCRIPTION
Changed config rules to send the whole log message in `content` attribute, to enabled text search in Dynatrace Log Viewer.
