### PR TITLE
APM-319866 fix string metrics metadata generations

### DIFF
--- a/src/lib/metrics.py
+++ b/src/lib/metrics.py
@@ -137,7 +137,6 @@ class GCPService:
             Metric(**x)
             for x
             in kwargs.get("metrics", {})
-            if x.get("gcpOptions", {}).get("valueType", "").upper() != "STRING"
         ])
         object.__setattr__(self, "activation", kwargs.get("activation", {}))
         monitoring_filter = kwargs.get("gcp_monitoring_filter", "")


### PR DESCRIPTION
@dtmawo for what it was needed? right now it fails scripts because it skipping all `STRING` metrics