### PR TITLE
[APM-326992] GCP- project env

### DIFF
--- a/src/lib/credentials.py
+++ b/src/lib/credentials.py
@@ -94,7 +94,7 @@ async def create_default_service_account_token(context: LoggingContext, session:
 
 
 def get_project_id_from_environment():
-    return os.environ.get("GCP_PROJECT", "dynatrace-gcp-extension")
+    return os.environ.get("GCP_PROJECT")
 
 
 async def create_token(context: LoggingContext, session: ClientSession):

--- a/src/lib/credentials.py
+++ b/src/lib/credentials.py
@@ -94,7 +94,7 @@ async def create_default_service_account_token(context: LoggingContext, session:
 
 
 def get_project_id_from_environment():
-    return os.environ.get("GCP_PROJECT")
+    return os.environ.get("GCP_PROJECT", "dynatrace-gcp-extension")
 
 
 async def create_token(context: LoggingContext, session: ClientSession):

--- a/tests/integration/logs/test_integration.py
+++ b/tests/integration/logs/test_integration.py
@@ -48,10 +48,10 @@ system_variables = {
     'DYNATRACE_LOG_INGEST_URL': 'http://localhost:' + str(MOCKED_API_PORT),
     'DYNATRACE_ACCESS_KEY': ACCESS_KEY,
     'REQUIRE_VALID_CERTIFICATE': 'False',
+    'GCP_PROJECT': 'dynatrace-gcp-extension'
     # Set below-mentioned environment variables to push custom metrics to GCP Monitor
     # 'SELF_MONITORING_ENABLED': 'True',
     # 'GOOGLE_APPLICATION_CREDENTIALS': '',
-    # 'GCP_PROJECT': '',
     # 'LOGS_SUBSCRIPTION_ID': ''
 }
 

--- a/tests/integration/metrics/test_integration_metric.py
+++ b/tests/integration/metrics/test_integration_metric.py
@@ -41,7 +41,8 @@ MonkeyPatchFixture = NewType("MonkeyPatchFixture", Any)
 system_variables: Dict = {
     'DYNATRACE_URL': 'http://localhost:' + str(MOCKED_API_PORT),
     'REQUIRE_VALID_CERTIFICATE': 'False',
-    'GCP_SERVICES': "gce_instance/default,api/default,gce_instance/default,cloudsql_database/default,apigee.googleapis.com/Environment/default"
+    'GCP_SERVICES': "gce_instance/default,api/default,gce_instance/default,cloudsql_database/default,apigee.googleapis.com/Environment/default",
+    'GCP_PROJECT': 'dynatrace-gcp-extension'
     # 'DYNATRACE_ACCESS_KEY': ACCESS_KEY, this one is encoded in mocks files
 }
 


### PR DESCRIPTION
- [k8s installation] project_id is taken now from environment variable GCP_PROJECT or in case it's not available(tests) a default "dynatrace-gcp-extension" value is used
- added documentation.