### PR TITLE
Extensions fixes

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -273,7 +273,7 @@ activate_extension_on_cluster() {
     # missing extension in cluster installing it
     upload_extension_to_cluster "${EXTENSION_ZIP}" "${EXTENSION_VERSION}"
   elif [ "$(versionNumber ${EXTENSION_VERSION})" -gt "$(versionNumber ${EXTENSION_IN_DT: -5})" ]; then
-    # cluster has never version warning and install if flag was set
+    # cluster has newer version warning and install if flag was set
     if [ -n "${UPGRADE_EXTENSIONS}" ]; then
       upload_extension_to_cluster "${EXTENSION_ZIP}" "${EXTENSION_VERSION}"
     else

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -227,7 +227,7 @@ if [ "$INSTALL" == true ]; then
 fi
 
 echo "Please provide the URL used to access Dynatrace, for example: https://mytenant.live.dynatrace.com/"
-while ! [[ "${DYNATRACE_URL}" =~ ^(https?:\/\/[-a-zA-Z0-9@:%._+~=]{1,256}\/)(e\/[a-z0-9-]{36}\/)?$ ]]; do
+while ! [[ "${DYNATRACE_URL}" =~ $DYNATRACE_URL_REGEX ]]; do
   read -p "Enter Dynatrace tenant URI: " DYNATRACE_URL
 done
 echo ""
@@ -310,7 +310,7 @@ get_extensions_zip_packages
 
 echo -e
 echo "- checking activated extensions in Dynatrace"
-get_activated_extensions_on_cluster "$DYNATRACE_URL" "$DYNATRACE_ACCESS_KEY"
+EXTENSIONS_FROM_CLUSTER=$(get_activated_extensions_on_cluster)
 
 mv $TMP_FUNCTION_DIR $WORKING_DIR/$GCP_FUNCTION_NAME >/dev/null
 pushd $WORKING_DIR/$GCP_FUNCTION_NAME || exit

--- a/src/lib/extensions_fetcher.py
+++ b/src/lib/extensions_fetcher.py
@@ -12,39 +12,18 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import os
-
-import yaml
 import zipfile
 from io import BytesIO
 from typing import NamedTuple, List, Dict, Optional
 
+import yaml
 from aiohttp import ClientSession
 
-from lib.context import LoggingContext, get_should_require_valid_certificate, get_selected_services
+from lib.context import LoggingContext, get_should_require_valid_certificate
 from lib.metrics import GCPService
+from lib.utilities import read_activation_yaml, get_activation_config_per_service, load_activated_feature_sets
 
 ExtensionsFetchResult = NamedTuple('ExtensionsFetchResult', [('services', List[GCPService])])
-
-
-def load_activated_service_names(logging_context: LoggingContext) -> List[str]:
-    activation_file_path = '/code/config/activation/gcp_services.yaml'
-    try:
-        with open(activation_file_path, encoding="utf-8") as activation_file:
-            activation_yaml = yaml.safe_load(activation_file)
-    except Exception:
-        activation_yaml = yaml.safe_load(os.environ.get("ACTIVATION_CONFIG", ""))
-    if not activation_yaml:
-        return []
-    services_whitelist = []
-    for service in activation_yaml.get('services', []):
-        feature_sets = service.get("featureSets", [])
-        for feature_set in feature_sets:
-            services_whitelist.append(f"{service.get('service')}/{feature_set}")
-        if not feature_sets:
-            logging_context.error(f"No feature set in given {service} service.")
-
-    return services_whitelist
 
 
 class ExtensionsFetcher:
@@ -57,11 +36,20 @@ class ExtensionsFetcher:
 
     async def execute(self) -> ExtensionsFetchResult:
         extension_name_to_version_dict = await self._get_extensions_dict_from_dynatrace_cluster()
-        services = []
+        activation_yaml = read_activation_yaml()
+        activation_config_per_service = get_activation_config_per_service(activation_yaml)
+        feature_sets_from_activation_config = load_activated_feature_sets(self.logging_context, activation_yaml)
+
+        configured_services = []
+        not_configured_services = []
+
         for extension_name, extension_version in extension_name_to_version_dict.items():
-            services_for_extension = await self._get_service_configs_for_extension(extension_name, extension_version)
-            services.extend(services_for_extension)
-        configured_services = self._filter_out_not_configured_services(services) if services else []
+            configured_services_for_extension, not_configured_services_for_extension = await self._get_service_configs_for_extension(
+                extension_name, extension_version, activation_config_per_service, feature_sets_from_activation_config)
+            configured_services.extend(configured_services_for_extension)
+            not_configured_services.extend(not_configured_services_for_extension)
+        if not_configured_services:
+            self.logging_context.log(f"Following services from extensions are filtered out, because not found in 'gcpServicesYaml': {not_configured_services}")
         return ExtensionsFetchResult(services=configured_services)
 
     async def _get_extensions_dict_from_dynatrace_cluster(self) -> Dict[str, str]:
@@ -102,13 +90,25 @@ class ExtensionsFetcher:
                 dynatrace_extensions_dict[extension.get("extensionName")] = extension.get("version")
         return dynatrace_extensions_dict
 
-    async def _get_service_configs_for_extension(self, extension_name: str, extension_version: str) -> List[GCPService]:
+    async def _get_service_configs_for_extension(self, extension_name: str, extension_version: str,
+                                                 activation_config_per_service, feature_sets_from_activation_config) -> (List[GCPService], List):
         extension_zip = await self._get_extension_zip_from_dynatrace_cluster(extension_name, extension_version)
         extension_configuration = self._load_extension_config_from_zip(extension_name, extension_zip) if extension_zip else {}
         if "gcp" not in extension_configuration:
             self.logging_context.log(f"Incorrect extension fetched from Dynatrace cluster. {extension_name}-{extension_version} has no 'gcp' section and will be skipped")
             return []
-        return [GCPService(**feature_set) for feature_set in extension_configuration.get("gcp")]
+
+        configured_services = []
+        not_configured_services = []
+        for service in extension_configuration.get("gcp"):
+            service_name = service.get('service')
+            feature_set = f"{service_name}/{service.get('featureSet')}"
+            if feature_set in feature_sets_from_activation_config:
+                activation = activation_config_per_service.get(service_name, {})
+                configured_services.append(GCPService(**service, activation=activation))
+            else:
+                not_configured_services.append(feature_set)
+        return configured_services, not_configured_services
 
     async def _get_extension_zip_from_dynatrace_cluster(self, extension_name, extension_version) -> Optional[bytes]:
         url = f"{self.dynatrace_url.rstrip('/')}/api/v2/extensions/{extension_name}/{extension_version}"
@@ -133,20 +133,3 @@ class ExtensionsFetcher:
         except Exception:
             self.logging_context.t_exception(f"Cannot load extension {extension_name}")
         return activation_yaml
-
-    def _filter_out_not_configured_services(self, services_from_extensions: List[GCPService]) -> List[GCPService]:
-        services_from_env = set(load_activated_service_names(self.logging_context))
-        services_from_extensions_dict = {f"{gcp_service_config.name}/{gcp_service_config.feature_set}": gcp_service_config
-                                         for gcp_service_config in services_from_extensions}
-
-        services_in_env_but_no_in_extensions = services_from_env.difference(set(services_from_extensions_dict.keys()))
-        if services_in_env_but_no_in_extensions:
-            self.logging_context.log(
-                f"Following services are not found in extensions, but defined in 'gcpServicesYaml' env: {services_in_env_but_no_in_extensions}")
-        services_not_configured = set(services_from_extensions_dict.keys()).difference(services_from_env)
-        if services_not_configured:
-            self.logging_context.log(f"Following services from extensions are filtered out, because not found in 'gcpServicesYaml' env: {services_not_configured}")
-            return [services_from_extensions_dict[service_name] for service_name in services_from_extensions_dict.keys()
-                    if service_name not in services_not_configured]
-        else:
-            return services_from_extensions

--- a/src/lib/utilities.py
+++ b/src/lib/utilities.py
@@ -11,9 +11,43 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
+import os
 from typing import List
+
+import yaml
+
+from lib.context import LoggingContext
 
 
 def chunks(full_list: List, chunk_size: int) -> List[List]:
     chunk_size = max(1, chunk_size)
     return [full_list[i:i + chunk_size] for i in range(0, len(full_list), chunk_size)]
+
+
+def read_activation_yaml():
+    activation_file_path = '/code/config/activation/gcp_services.yaml'
+    try:
+        with open(activation_file_path, encoding="utf-8") as activation_file:
+            activation_yaml = yaml.safe_load(activation_file)
+    except Exception:
+        activation_yaml = yaml.safe_load(os.environ.get("ACTIVATION_CONFIG", ""))
+    if not activation_yaml:
+        activation_yaml = {}
+    return activation_yaml
+
+
+def get_activation_config_per_service(activation_yaml):
+    return {service_activation.get('service'): service_activation for service_activation in
+            activation_yaml['services']} if activation_yaml and activation_yaml['services'] else {}
+
+
+def load_activated_feature_sets(logging_context: LoggingContext, activation_yaml) -> List[str]:
+    services_whitelist = []
+    for service in activation_yaml.get("services"):
+        feature_sets = service.get("featureSets", [])
+        for feature_set in feature_sets:
+            services_whitelist.append(f"{service.get('service')}/{feature_set}")
+        if not feature_sets:
+            logging_context.error(f"No feature set in given {service} service.")
+
+    return services_whitelist

--- a/tests/e2e/extensions/test_types.py
+++ b/tests/e2e/extensions/test_types.py
@@ -27,7 +27,6 @@ testdata = [
     'cloud:gcp:gce_instance',
     'cloud:gcp:autoscaler',
     'cloud:gcp:tpu_worker',
-    'cloud:gcp:datastore_request',
     'cloud:gcp:filestore_instance',
     'cloud:gcp:https_lb',
     'cloud:gcp:internal_http_lb_rule',

--- a/tests/unit/test_activation_config.py
+++ b/tests/unit/test_activation_config.py
@@ -16,7 +16,7 @@ from typing import NewType, Any
 from assertpy import assert_that
 
 from lib.context import LoggingContext
-from lib.extensions_fetcher import load_activated_service_names
+from lib.utilities import read_activation_yaml, load_activated_feature_sets
 
 context = LoggingContext("TEST")
 MonkeyPatchFixture = NewType("MonkeyPatchFixture", Any)
@@ -32,24 +32,28 @@ ACTIVATION_CONFIG_WITH_EMPTY_FEATURE_SET = "{services: [{service: you_shall_not_
 
 def test_filtering_config_loaded(monkeypatch: MonkeyPatchFixture):
     monkeypatch.setenv("ACTIVATION_CONFIG", ACTIVATION_CONFIG)
-    activated_service_names = load_activated_service_names(context)
+    activation_yaml = read_activation_yaml()
+    activated_service_names = load_activated_feature_sets(context, activation_yaml)
     assert_that(activated_service_names).contains_only("pubsub_subscription/default_metrics", "pubsub_subscription/test",
                                                        "pubsub_snapshot/default_metrics")
 
 
 def test_filtering_missing_configs(monkeypatch: MonkeyPatchFixture):
     monkeypatch.setenv("ACTIVATION_CONFIG", "{services: []}")
-    config = load_activated_service_names(context)
+    activation_yaml = read_activation_yaml()
+    config = load_activated_feature_sets(context, activation_yaml)
     assert len(config) == 0
 
 
 def test_filtering_services_without_feature_sets(monkeypatch: MonkeyPatchFixture):
     monkeypatch.setenv("ACTIVATION_CONFIG", ACTIVATION_CONFIG_WITHOUT_FEATURE_SET)
-    activated_service_names = load_activated_service_names(context)
+    activation_yaml = read_activation_yaml()
+    activated_service_names = load_activated_feature_sets(context, activation_yaml)
     assert_that(activated_service_names).contains_only("services_to_be_activated/default_metrics")
 
 
 def test_services_with_an_empty_feature_sets(monkeypatch: MonkeyPatchFixture):
     monkeypatch.setenv("ACTIVATION_CONFIG", ACTIVATION_CONFIG_WITH_EMPTY_FEATURE_SET)
-    activated_service_names = load_activated_service_names(context)
+    activation_yaml = read_activation_yaml()
+    activated_service_names = load_activated_feature_sets(context, activation_yaml)
     assert_that(activated_service_names).contains_only("services_to_be_activated/default_metrics", "services_to_be_activated/test")

--- a/tests/unit/test_extension_fetcher.py
+++ b/tests/unit/test_extension_fetcher.py
@@ -25,13 +25,11 @@ from lib.context import LoggingContext
 from lib.extensions_fetcher import ExtensionsFetcher
 
 MonkeyPatchFixture = NewType("MonkeyPatchFixture", Any)
-ACTIVATION_CONFIG = "{services: [{service: gce_instance, featureSets: [default_metrics, agent], vars: {filter_conditions: ''}},\
+ACTIVATION_CONFIG = "{services: [{service: gce_instance, featureSets: [default_metrics, agent], vars: {filter_conditions: 'resource.labels.instance_name=starts_with(\"test\")'}},\
  {service: cloudsql_database, featureSets: [default_metrics], vars: {filter_conditions: ''}}]}"
 
 @pytest.fixture(scope="function", autouse=True)
 def setup_env(monkeypatch, resource_path_root):
-    # NO filestore/default configured
-    monkeypatch.setenv("ACTIVATION_CONFIG", ACTIVATION_CONFIG)
     Response.resource_path_root = resource_path_root
 
 
@@ -70,13 +68,36 @@ def mocked_get(url: str, headers={}, params={}, verify_ssl=False):
             returned_future.set_result(None)
     return returned_future
 
+
 @pytest.mark.asyncio
-async def test_execute(mocker: MockerFixture):
+async def test_execute(mocker: MockerFixture, monkeypatch: MonkeyPatchFixture):
+    # NO filestore/default configured
+    monkeypatch.setenv("ACTIVATION_CONFIG", ACTIVATION_CONFIG)
     dt_session = ClientSession()
     mocker.patch.object(dt_session, 'get', side_effect=mocked_get)
 
     extensions_fetcher = ExtensionsFetcher(dt_session, "", "", LoggingContext("TEST"))
     result = await extensions_fetcher.execute()
     assert_that(result).is_not_none()
-    services_names = [f"{gcp_service_config.name}/{gcp_service_config.feature_set}" for gcp_service_config in result.services]
-    assert_that(services_names).contains_only("gce_instance/default_metrics", "gce_instance/agent", "cloudsql_database/default_metrics")
+    feature_sets_to_filter_conditions = {f"{gcp_service_config.name}/{gcp_service_config.feature_set}": gcp_service_config.monitoring_filter
+                                         for gcp_service_config in result.services}
+    assert_that(feature_sets_to_filter_conditions).is_equal_to({"cloudsql_database/default_metrics": "",
+                                                                  "gce_instance/default_metrics": "resource.labels.instance_name=starts_with(\"test\")",
+                                                                  "gce_instance/agent": "resource.labels.instance_name=starts_with(\"test\")"})
+
+
+@pytest.mark.asyncio
+async def test_empty_activation_config(mocker: MockerFixture, monkeypatch: MonkeyPatchFixture):
+    # NO filestore/default configured
+    monkeypatch.setenv("ACTIVATION_CONFIG", "{services: []}")
+
+    dt_session = ClientSession()
+    mocker.patch.object(dt_session, 'get', side_effect=mocked_get)
+
+    extensions_fetcher = ExtensionsFetcher(dt_session, "", "", LoggingContext("TEST"))
+    result = await extensions_fetcher.execute()
+    assert_that(result).is_not_none()
+    feature_sets_to_filter_conditions = {f"{gcp_service_config.name}/{gcp_service_config.feature_set}": gcp_service_config.monitoring_filter
+                                         for gcp_service_config in result.services}
+    assert_that(feature_sets_to_filter_conditions).is_equal_to({})
+


### PR DESCRIPTION
Fixes:
- filtering for k8s deployment
- do not upload extensions which are already uploaded to the cluster (setup.sh)
- not required last '/' in cluster url (setup.sh)