### PR TITLE
[APM-345587] Changed `activeGate.useExisting` default value to true i…

### DIFF
--- a/k8s/helm-chart/dynatrace-gcp-function/values.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-function/values.yaml
@@ -42,8 +42,8 @@ logsSubscriptionId: ""
 dynatraceLogIngestUrl: ""
 
 activeGate:
-  #useExisting if set to false (by default) the Active Gate will be deployed in k8s. In that case also the activeGate.dynatracePaasToken must be filled.
-  useExisting: "false"
+  #useExisting if set to true (by default) integration will used existing Active Gate, if it set to false the Active Gate will be deployed in k8s. In that case also the activeGate.dynatracePaasToken must be filled.
+  useExisting: "true"
   #dynatracePaasToken PaaS token, generated in Dynatrace cluster.
   dynatracePaasToken: ""
 

--- a/k8s/helm-chart/dynatrace-gcp-function/values.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-function/values.yaml
@@ -42,7 +42,8 @@ logsSubscriptionId: ""
 dynatraceLogIngestUrl: ""
 
 activeGate:
-  #useExisting if set to true (by default) integration will used existing Active Gate, if it set to false the Active Gate will be deployed in k8s. In that case also the activeGate.dynatracePaasToken must be filled.
+  #useExisting if you choose to use direct ingest through the Cluster API or existing ActiveGate, put 'true' (default).
+  #If you choose new ActiveGate deployment, put 'false', the Active Gate will be deployed in k8s. In such case also the activeGate.dynatracePaasToken must be filled.
   useExisting: "true"
   #dynatracePaasToken PaaS token, generated in Dynatrace cluster.
   dynatracePaasToken: ""

--- a/k8s/helm-chart/dynatrace-gcp-function/values.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-function/values.yaml
@@ -42,7 +42,7 @@ logsSubscriptionId: ""
 dynatraceLogIngestUrl: ""
 
 activeGate:
-  #useExisting if you choose to use direct ingest through the Cluster API or existing ActiveGate, put 'true' (default).
+  #useExisting if you choose to use direct ingest through the Cluster API (available to all SaaS customers) or existing ActiveGate, put 'true' (default).
   #If you choose new ActiveGate deployment, put 'false', the Active Gate will be deployed in k8s. In such case also the activeGate.dynatracePaasToken must be filled.
   useExisting: "true"
   #dynatracePaasToken PaaS token, generated in Dynatrace cluster.


### PR DESCRIPTION
Changed `activeGate.useExisting` default value to true in values.yaml.
Since the public ingest for logs and metrics is available, using an existing Active Gate should be used as a default approach. 