### PR TITLE
bugfix/APM-344818

### DIFF
--- a/scripts/deploy-helm.sh
+++ b/scripts/deploy-helm.sh
@@ -170,10 +170,7 @@ API_TOKEN_SCOPES=('"logs.ingest"' '"metrics.ingest"' '"ReadConfig"' '"WriteConfi
 
 check_s3_url
 
-if [ -z "$GCP_PROJECT" ]; then
-  err "Invalid GCP_PROJECT. Set correct gcpProjectId in values.yaml"
-  exit 1
-fi
+check_if_parameter_is_empty "$GCP_PROJECT" "Set correct gcpProjectId in values.yaml"
 
 gcloud config set project "$GCP_PROJECT"
 echo "- Deploying dynatrace-gcp-function in [$GCP_PROJECT]"

--- a/scripts/deploy-helm.sh
+++ b/scripts/deploy-helm.sh
@@ -171,11 +171,8 @@ API_TOKEN_SCOPES=('"logs.ingest"' '"metrics.ingest"' '"ReadConfig"' '"WriteConfi
 check_s3_url
 
 if [ -z "$GCP_PROJECT" ]; then
-  GCP_PROJECT=$(gcloud config get-value project 2>/dev/null)
-  if [ -z "$GCP_PROJECT" ]; then
-    err "Invalid GCP_PROJECT. Set correct gcpProjectId in values.yaml"
-    exit 1
-  fi
+  err "Invalid GCP_PROJECT. Set correct gcpProjectId in values.yaml"
+  exit 1
 fi
 
 gcloud config set project "$GCP_PROJECT"


### PR DESCRIPTION
After some discussion with @mswiatkowska we decided not to complicate the setup and to remove the option to auto-set the GCP Project ID based on cloud or local shell settings. Based on the docs, users are required to set the parameter in `values.yaml` file before script execution and should receive an error message otherwise.