### PR TITLE
Fail fast on deployment errors in GCP k8s

### DIFF
--- a/scripts/deploy-helm.sh
+++ b/scripts/deploy-helm.sh
@@ -21,6 +21,7 @@ init_ext_tools
 
 trap ctrl_c INT
 trap onFailure ERR
+set -o pipefail
 
 info "\033[1;34mDynatrace GCP integration on GKE"
 info "\033[0;37m"


### PR DESCRIPTION
The issue lied in piping commands into tee - if the piped commanded exited with non-zero status, the trap wasn't triggered.

Setting the pipefail shell option fixes the issue. 

Without setting pipefail:
![bad-fail](https://user-images.githubusercontent.com/32064437/160420555-0b11668a-9131-4f08-b7c5-2a5b4cbf479a.png)

With pipefail:

![good-fail](https://user-images.githubusercontent.com/32064437/160420631-e4a94ff8-3f56-4684-b1d6-192b955e84f6.png)

