### PR TITLE
Bugfix/apm 363386 gke deployment respect service account param

### DIFF
--- a/k8s/helm-chart/dynatrace-gcp-function/templates/function-deployment.yml
+++ b/k8s/helm-chart/dynatrace-gcp-function/templates/function-deployment.yml
@@ -15,10 +15,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: dynatrace-gcp-function-sa
+  name: {{ .Values.serviceAccount }}
   namespace: {{ .Release.Namespace }}
   "annotations": {
-    "iam.gke.io/gcp-service-account" : dynatrace-gcp-function-sa@{{ .Values.gcpProjectId }}.iam.gserviceaccount.com
+    "iam.gke.io/gcp-service-account" : {{ .Values.serviceAccount }}@{{ .Values.gcpProjectId }}.iam.gserviceaccount.com
   }
 automountServiceAccountToken: false
 ---
@@ -43,7 +43,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/function-config.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/function-secret.yaml") . | sha256sum }}
     spec:
-      serviceAccountName: dynatrace-gcp-function-sa
+      serviceAccountName: {{ .Values.serviceAccount }}
       automountServiceAccountToken: false
       {{- if or (eq .Values.deploymentType "metrics") (eq .Values.deploymentType "all") }}
       volumes:

--- a/k8s/helm-chart/dynatrace-gcp-function/values.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-function/values.yaml
@@ -60,6 +60,8 @@ requireValidCertificate: "true"
 # Send custom metrics to GCP to diagnose quickly if your dynatrace-gcp-function processes and sends metrics/logs to Dynatrace properly.
 # Allowed values: "true"/"yes", "false"/"no"
 selfMonitoringEnabled: "false"
+# IAM service account name
+serviceAccount: "dynatrace-gcp-function-sa"
 # Dynatrace GCP function docker image. Using default value is advised,
 # but can be changed if there is a need to use customized image or specific, tagged version
 dockerImage: "dynatrace/dynatrace-gcp-function:v1-latest"

--- a/scripts/deploy-helm.sh
+++ b/scripts/deploy-helm.sh
@@ -70,12 +70,9 @@ check_dynatrace_docker_login() {
 
 print_help() {
   printf "
-usage: deploy-helm.sh [--service-account SA_NAME] [--role-name ROLE_NAME] [--create-autopilot-cluster] [--autopilot-cluster-name CLUSTER_NAME] [--upgrade-extensions] [--auto-default] [--quiet]
+usage: deploy-helm.sh [--role-name ROLE_NAME] [--create-autopilot-cluster] [--autopilot-cluster-name CLUSTER_NAME] [--upgrade-extensions] [--auto-default] [--quiet]
 
 arguments:
-    --service-account SA_NAME
-                            IAM service account name
-                            By default 'dynatrace-gcp-function-sa' will be used.
     --role-name ROLE_NAME
                             IAM role name prefix
                             By default 'dynatrace_function' will be used as prefix (e.g. dynatrace_function.metrics).
@@ -110,11 +107,6 @@ AUTOPILOT_CLUSTER_NAME="dynatrace-gcp-function"
 
 while (( "$#" )); do
     case "$1" in
-            "--service-account")
-                SA_NAME=$2
-                shift; shift
-            ;;
-
             "--role-name")
                 ROLE_NAME=$2
                 shift; shift
@@ -189,6 +181,8 @@ readonly HTTP_PROXY
 HTTPS_PROXY=$(helm show values ./dynatrace-gcp-function --jsonpath "{.httpsProxy}")
 readonly HTTPS_PROXY
 readonly ACTIVE_GATE_TARGET_URL_REGEX="^https:\/\/[-a-zA-Z0-9@:%._+~=]{1,256}\/e\/[-a-z0-9]{1,36}[\/]{0,1}$"
+SA_NAME=$(helm show values ./dynatrace-gcp-function --jsonpath "{.serviceAccount}")
+readonly SA_NAME
 
 SERVICES_FROM_ACTIVATION_CONFIG=$("$YQ" e '.gcpServicesYaml' ./dynatrace-gcp-function/values.yaml | "$YQ" e -j '.services[]' - | "$JQ" -r '. | "\(.service)/\(.featureSets[])"')
 
@@ -201,10 +195,6 @@ check_if_parameter_is_empty "$GCP_PROJECT" "Set correct gcpProjectId in values.y
 
 gcloud config set project "$GCP_PROJECT" | tee -a "$FULL_LOG_FILE"
 info "- Deploying dynatrace-gcp-function in [$GCP_PROJECT]"
-
-if [ -z "$SA_NAME" ]; then
-  SA_NAME="dynatrace-gcp-function-sa"
-fi
 
 if [ -z "$ROLE_NAME" ]; then
   ROLE_NAME="dynatrace_function"
@@ -391,7 +381,7 @@ fi
 debug "Binding correct policies to Service Account"
 info ""
 info "- 3. Configure the IAM service account for Workload Identity."
-gcloud iam service-accounts add-iam-policy-binding "$SA_NAME@$GCP_PROJECT.iam.gserviceaccount.com" --role roles/iam.workloadIdentityUser --member "serviceAccount:$GCP_PROJECT.svc.id.goog[$KUBERNETES_NAMESPACE/dynatrace-gcp-function-sa]" | tee -a "$FULL_LOG_FILE" >${CMD_OUT_PIPE}
+gcloud iam service-accounts add-iam-policy-binding "$SA_NAME@$GCP_PROJECT.iam.gserviceaccount.com" --role roles/iam.workloadIdentityUser --member "serviceAccount:$GCP_PROJECT.svc.id.goog[$KUBERNETES_NAMESPACE/$SA_NAME]" | tee -a "$FULL_LOG_FILE" >${CMD_OUT_PIPE}
 
 info ""
 info "- 4. Create dynatrace-gcp-function IAM role(s)."

--- a/tests/e2e/deployment-test.sh
+++ b/tests/e2e/deployment-test.sh
@@ -98,12 +98,13 @@ dockerImage: "${GCR_NAME}:e2e-travis-test-${TRAVIS_BUILD_ID}"
 activeGate:
   useExisting: "false"
   dynatracePaasToken: "${DYNATRACE_PAAS_TOKEN}"
+serviceAccount: "${IAM_SERVICE_ACCOUNT}"
 EOF
 "$TEST_YQ" eval-all --inplace 'select(fileIndex == 0) * select(fileIndex == 1)' ${VALUES_FILE} values.e2e.yaml
 
 gcloud container clusters get-credentials "${K8S_CLUSTER}" --region us-central1 --project "${GCP_PROJECT_ID}"
 
-./deploy-helm.sh --service-account "${IAM_SERVICE_ACCOUNT}" --role-name "${IAM_ROLE_PREFIX}" --quiet || exit 1
+./deploy-helm.sh --role-name "${IAM_ROLE_PREFIX}" --quiet || exit 1
 
 # Verify containers running
 echo


### PR DESCRIPTION
Script used to have --service-acount param which was not really respected. SA with given name was created but helm deployment used hardcoded default value everywhere. 
Now param is extracted to values.yaml and is respected both in SA creation during deployment and SA assingment in helm templates. 