### PR TITLE
Bugfix/apm 362265 gcp get disabled apis call loops forever

### DIFF
--- a/src/lib/entities/google_api.py
+++ b/src/lib/entities/google_api.py
@@ -50,13 +50,13 @@ async def generic_paging(
             return entities
 
         if resp.status >= 400:
-            ctx.log(f'Failed to retrieve information from googleapis. {url} {page}')
+            ctx.log(project_id, f'Failed to retrieve information from googleapis. {url} {page}')
             return entities
 
         try:
             entities.extend(mapper(page))
         except Exception as ex:
-            ctx.log(f"Failed to map response from googleapis. {url} {ex}")
+            ctx.log(project_id, f"Failed to map response from googleapis. {url} {ex}")
             return entities
 
         get_page = "nextPageToken" in page

--- a/src/lib/gcp_apis.py
+++ b/src/lib/gcp_apis.py
@@ -24,14 +24,12 @@ async def get_all_disabled_apis(context: MetricsContext, token: str, project_id:
     disabled_apis = set()
     try:
         response = await context.gcp_session.get(base_url, headers=headers, raise_for_status=True)
-        context.log(f'Initial response {response}')
         disabled_services_json = await response.json()
         disabled_services = disabled_services_json.get("services", [])
         disabled_apis.update({disable_service.get("config", {}).get("name", "") for disable_service in disabled_services})
         while disabled_services_json.get("nextPageToken"):
             url = f"{base_url}&pageToken={disabled_services_json['nextPageToken']}"
             response = await context.gcp_session.get(url, headers=headers, raise_for_status=True)
-            context.log(f'Continued response {response}')
             disabled_services_json = await response.json()
             disabled_services = disabled_services_json.get("services", [])
             disabled_apis.update({disable_service.get("config", {}).get("name", "") for disable_service in disabled_services})

--- a/src/lib/gcp_apis.py
+++ b/src/lib/gcp_apis.py
@@ -19,17 +19,17 @@ GCP_SERVICE_USAGE_URL = "https://serviceusage.googleapis.com/v1/projects/"
 
 
 async def get_all_disabled_apis(context: MetricsContext, token: str, project_id: str):
-    url = f"{GCP_SERVICE_USAGE_URL}{project_id}/services?filter=state:DISABLED"
+    base_url = f"{GCP_SERVICE_USAGE_URL}{project_id}/services?filter=state:DISABLED"
     headers = {"Authorization": "Bearer {token}".format(token=token)}
     disabled_apis = set()
     try:
-        response = await context.gcp_session.get(url, headers=headers, raise_for_status=True)
+        response = await context.gcp_session.get(base_url, headers=headers, raise_for_status=True)
         context.log(f'Initial response {response}')
         disabled_services_json = await response.json()
         disabled_services = disabled_services_json.get("services", [])
         disabled_apis.update({disable_service.get("config", {}).get("name", "") for disable_service in disabled_services})
         while disabled_services_json.get("nextPageToken"):
-            url = f"{url}&pageToken={disabled_services_json['nextPageToken']}"
+            url = f"{base_url}&pageToken={disabled_services_json['nextPageToken']}"
             response = await context.gcp_session.get(url, headers=headers, raise_for_status=True)
             context.log(f'Continued response {response}')
             disabled_services_json = await response.json()

--- a/src/lib/gcp_apis.py
+++ b/src/lib/gcp_apis.py
@@ -11,6 +11,7 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
+from aiohttp import ClientResponseError
 
 from lib.context import MetricsContext
 
@@ -22,21 +23,22 @@ async def get_all_disabled_apis(context: MetricsContext, token: str, project_id:
     headers = {"Authorization": "Bearer {token}".format(token=token)}
     disabled_apis = set()
     try:
-        response = await context.gcp_session.get(url, headers=headers)
-        if response.status != 200:
-            context.log(f'Http error: {response.status}, url: {response.url}, reason: {response.reason}')
-            return set()
+        response = await context.gcp_session.get(url, headers=headers, raise_for_status=True)
+        context.log(f'Initial response {response}')
         disabled_services_json = await response.json()
         disabled_services = disabled_services_json.get("services", [])
         disabled_apis.update({disable_service.get("config", {}).get("name", "") for disable_service in disabled_services})
         while disabled_services_json.get("nextPageToken"):
             url = f"{url}&pageToken={disabled_services_json['nextPageToken']}"
-            response = await context.gcp_session.get(url, headers=headers)
-            if response.status == 200:
-                disabled_services_json = await response.json()
-                disabled_services = disabled_services_json.get("services", [])
-                disabled_apis.update({disable_service.get("config", {}).get("name", "") for disable_service in disabled_services})
+            response = await context.gcp_session.get(url, headers=headers, raise_for_status=True)
+            context.log(f'Continued response {response}')
+            disabled_services_json = await response.json()
+            disabled_services = disabled_services_json.get("services", [])
+            disabled_apis.update({disable_service.get("config", {}).get("name", "") for disable_service in disabled_services})
+        return disabled_apis
+    except ClientResponseError as e:
+        context.log(f'Disabled APIs call returned failed status code. {e}')
         return disabled_apis
     except Exception as e:
-        context.log(f'Cannot get disabled APIs: {GCP_SERVICE_USAGE_URL}/projects/{project_id}/services?filter = state:DISABLED. {e}')
+        context.log(f'Cannot get disabled APIs: {GCP_SERVICE_USAGE_URL}/projects/{project_id}/services?filter=state:DISABLED. {e}')
         return disabled_apis

--- a/src/lib/gcp_apis.py
+++ b/src/lib/gcp_apis.py
@@ -35,8 +35,8 @@ async def get_all_disabled_apis(context: MetricsContext, token: str, project_id:
             disabled_apis.update({disable_service.get("config", {}).get("name", "") for disable_service in disabled_services})
         return disabled_apis
     except ClientResponseError as e:
-        context.log(f'Disabled APIs call returned failed status code. {e}')
+        context.log(project_id, f'Disabled APIs call returned failed status code. {e}')
         return disabled_apis
     except Exception as e:
-        context.log(f'Cannot get disabled APIs: {GCP_SERVICE_USAGE_URL}/projects/{project_id}/services?filter=state:DISABLED. {e}')
+        context.log(project_id, f'Cannot get disabled APIs: {GCP_SERVICE_USAGE_URL}/projects/{project_id}/services?filter=state:DISABLED. {e}')
         return disabled_apis


### PR DESCRIPTION
Pagination in get disabled APIs call continued indefinetely on non-200 responses.
Additionally, each loop, an additional pageToken param was appended, creating impossibly long URLs, leading to 400s and 413s.
This led to the endpoint being always busy with too many calls.