### PR TITLE
add empty zone parameter to gcloud container calls

### DIFF
--- a/scripts/deploy-helm.sh
+++ b/scripts/deploy-helm.sh
@@ -366,8 +366,8 @@ if [[ $CREATE_AUTOPILOT_CLUSTER == "Y" ]]; then
   fi
   info ""
   info "- Create and connect GKE Autopilot k8s cluster ${AUTOPILOT_CLUSTER_NAME}."
-  gcloud container clusters create-auto "${AUTOPILOT_CLUSTER_NAME}" --project "${GCP_PROJECT}" | tee -a "$FULL_LOG_FILE" >${CMD_OUT_PIPE}
-  gcloud container clusters get-credentials "${AUTOPILOT_CLUSTER_NAME}" --project "${GCP_PROJECT}" | tee -a "$FULL_LOG_FILE" >${CMD_OUT_PIPE}
+  gcloud container clusters create-auto "${AUTOPILOT_CLUSTER_NAME}" --project "${GCP_PROJECT}" --zone "" | tee -a "$FULL_LOG_FILE" >${CMD_OUT_PIPE}
+  gcloud container clusters get-credentials "${AUTOPILOT_CLUSTER_NAME}" --project "${GCP_PROJECT}" --zone "" | tee -a "$FULL_LOG_FILE" >${CMD_OUT_PIPE}
 fi
 
 debug "Creating dynatrace namespace into kubernetes cluster"


### PR DESCRIPTION
Having compute/zone set in a command line tool lead to `gcloud container cluster` calls to automatically append a `--zone` parameter, which leads to an error when creating autopilot cluster: 
![image-2022-03-31-09-51-24-976](https://user-images.githubusercontent.com/32064437/161788797-19027a3c-3373-4481-88dc-e446319c0f9d.png)
Autopilot clusters have to be regional, but for some reason allow passing `--zone` .
Passing empty zone parameters fixes this issue.