### PR TITLE
build stage now triggers on release builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,6 @@ jobs:
 
   - stage: build
     name: Build
-    if: tag !~ /^release-.*
     language: python
     python:
       - "3.8"


### PR DESCRIPTION
e2e-helm-deployment-test stage uses artifacts in a GCP bucket which are created in the build stage. 
However, the build stage is only triggered by non-release builds causing release builds to fail on the test stage. 
Removing the 'if' should fix the issue.