### PR TITLE
Changed S3 to Cloudfront URL

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -240,7 +240,8 @@ check_api_token() {
 
 check_s3_url() {
   if [ -z "$EXTENSION_S3_URL" ]; then
-    EXTENSION_S3_URL="https://dynatrace-gcp-extensions.s3.amazonaws.com"
+    # File exposed in a S3 bucket accessed through Cloudfront
+    EXTENSION_S3_URL="https://d1twjciptxxqvo.cloudfront.net"
   else
     warn "Development mode on: custom S3 url link."
   fi


### PR DESCRIPTION
I only changed the default URL and added a comment to indicate that the file is accessed through Cloudfront.
All the variables names referencing a S3 bucket remain the same, as well as the argument name that the customer can use to select the file location during installation.