### PR TITLE
Existing AG property to true by default

### DIFF
--- a/scripts/deploy-helm.sh
+++ b/scripts/deploy-helm.sh
@@ -209,6 +209,10 @@ if [ -z "$KUBERNETES_NAMESPACE" ]; then
   KUBERNETES_NAMESPACE="dynatrace"
 fi
 
+if [ -z "$USE_EXISTING_ACTIVE_GATE" ]; then
+  USE_EXISTING_ACTIVE_GATE=true
+fi
+
 if [ -z "$DEPLOYMENT_TYPE" ]; then
   DEPLOYMENT_TYPE="all"
   info "Deploying metrics and logs ingest"


### PR DESCRIPTION
For the autopilot cluster deployment, this property is already true by default, so I am only setting it in case it is not defined at the beginning of the setup script.
If the property is set to false, the new AG is created in k8s, so for the cloud function deployment, there's no option, it always uses an existing AG.

