### PR TITLE
Increase maximum metric data points per minute

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -38,7 +38,7 @@ Worker function execution can be tweaked with environment variables. In Google F
 | DYNATRACE_ACCESS_KEY_SECRET_NAME | name of environment variable or Google Secret Manager Secret containing Dynatrace Access Key | DYNATRACE_ACCESS_KEY |
 | DYNATRACE_URL_SECRET_NAME | name of environment variable or Google Secret Manager Secret containing Dynatrace URL | DYNATRACE_URL |
 | GOOGLE_APPLICATION_CREDENTIALS | path to GCP service account key file | |
-| MAXIMUM_METRIC_DATA_POINTS_PER_MINUTE | Max number of MINT ingest lines processed in one minute interval | 100 000 |
+| MAXIMUM_METRIC_DATA_POINTS_PER_MINUTE | Max number of MINT ingest lines processed in one minute interval | 1 000 000 |
 | METRIC_INGEST_BATCH_SIZE | size of MINT ingest batch sent to Dynatrace cluster | 1000 |
 | REQUIRE_VALID_CERTIFICATE | determines whether worker will verify SSL certificate of Dynatrace endpoint. Allowed values: `true`/`yes`, `false`/`no` | `true` |
 | SERVICE_USAGE_BOOKING | `source` if API calls should use default billing mechanism, `destination` if they should be billed per project | `source` |

--- a/src/lib/context.py
+++ b/src/lib/context.py
@@ -282,7 +282,7 @@ class MetricsContext(SfmContext):
         self.execution_interval = timedelta(seconds=execution_interval_seconds)
         self.print_metric_ingest_input = print_metric_ingest_input
         self.self_monitoring_enabled = self_monitoring_enabled
-        self.maximum_metric_data_points_per_minute = get_int_environment_value("MAXIMUM_METRIC_DATA_POINTS_PER_MINUTE", 100000)
+        self.maximum_metric_data_points_per_minute = get_int_environment_value("MAXIMUM_METRIC_DATA_POINTS_PER_MINUTE", 1000000)
         self.metric_ingest_batch_size = get_int_environment_value("METRIC_INGEST_BATCH_SIZE", 1000)
         self.use_x_goog_user_project_header = {project_id_owner: False}
 


### PR DESCRIPTION
Increase the default of metric lines ingested due to relaxing limits on the metric ingest API.