### PR TITLE
Fix conditions of parameters validations and condition of invalid token permissions

### DIFF
--- a/scripts/deploy-helm.sh
+++ b/scripts/deploy-helm.sh
@@ -163,11 +163,11 @@ done
 
 GCP_PROJECT=$(helm show values ./dynatrace-gcp-function --jsonpath "{.gcpProjectId}")
 DEPLOYMENT_TYPE=$(helm show values ./dynatrace-gcp-function --jsonpath "{.deploymentType}")
-DYNATRACE_ACCESS_KEY=$(helm show values ./dynatrace-gcp-function --jsonpath "{.dynatraceAccessKey}")
+DYNATRACE_ACCESS_KEY=$(helm show values ./dynatrace-gcp-function --jsonpath "{.dynatraceAccessKey}" | sed 's/[\r\n\t ]//g')
 readonly DYNATRACE_ACCESS_KEY
-DYNATRACE_URL=$(helm show values ./dynatrace-gcp-function --jsonpath "{.dynatraceUrl}" | sed 's:/*$::')
+DYNATRACE_URL=$(helm show values ./dynatrace-gcp-function --jsonpath "{.dynatraceUrl}" | sed 's/[\r\n\t ]//g' | sed 's:/*$::')
 readonly DYNATRACE_URL
-DYNATRACE_LOG_INGEST_URL=$(helm show values ./dynatrace-gcp-function --jsonpath "{.dynatraceLogIngestUrl}" | sed 's:/*$::')
+DYNATRACE_LOG_INGEST_URL=$(helm show values ./dynatrace-gcp-function --jsonpath "{.dynatraceLogIngestUrl}" | sed 's/[\r\n\t ]//g' | sed 's:/*$::')
 if [ -z "$DYNATRACE_LOG_INGEST_URL" ]; then
   DYNATRACE_LOG_INGEST_URL=$DYNATRACE_URL
 fi

--- a/src/lib/fast_check.py
+++ b/src/lib/fast_check.py
@@ -138,9 +138,9 @@ async def check_dynatrace(logging_context: LoggingContext, project_id, dt_sessio
         token_metadata = await get_dynatrace_token_metadata(dt_session, logging_context, dynatrace_url, dynatrace_access_key)
         if token_metadata.get('name', None):
             logging_context.log(f"Token name: {token_metadata.get('name')}.")
-        if token_metadata.get('revoked', None) or not valid_dynatrace_scopes(token_metadata):
-            logging_context.log(f'Dynatrace API Token for project: \'{project_id}\' is not valid. '
-                                f'Check expiration time and required token scopes: {DYNATRACE_REQUIRED_TOKEN_SCOPES}')
+            if token_metadata.get('revoked', None) or not valid_dynatrace_scopes(token_metadata):
+                logging_context.log(f'Dynatrace API Token for project: \'{project_id}\' is not valid. '
+                                    f'Check expiration time and required token scopes: {DYNATRACE_REQUIRED_TOKEN_SCOPES}')
     except Exception as e:
         logging_context.log(f'Unable to get Dynatrace Secrets for project: {project_id}. Error details: {e}')
 


### PR DESCRIPTION
Changes:
- Set USE_EXISTING_ACTIVE_GATE to true by default before readonly statement.
- DYNATRACE_URL validations in every case, since it's now required.
- LOG_VIEWER URL for every case in which logs are ingested, since DYNATRACE_URL is now required.
- Log record indicating invalid token permissions is now displayed only in case the token was retrieved successfully but has incorrect scopes (or is revoked). Before this, if a network/communication error happened in the token call, the token_metadata variable was returned as an empty dict ({}) and this log was also displayed, which was misleading.
- Remove occurrences of whitespaces, \r, \n & \t in error prone parameters