### PR TITLE
PCLOUDS-1519 - fixing dead links in README

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -87,8 +87,8 @@ Limitations:
 `dynatrace-gcp-function` uses Dynatrace Extension Framework 2.0 to package support for GCP Services (metrics, topology rules, dashboards etc). The latest version of official GCP extensions is listed in [extensions-list.txt](https://d1twjciptxxqvo.cloudfront.net/extensions-list.txt) manifest file.
 
 Reference:
-* [Extension YAML file](https://www.dynatrace.com/support/help/extend-dynatrace/extensions20/extension-yaml)
-* [Sign extensions](https://www.dynatrace.com/support/help/extend-dynatrace/extensions20/sign-extension)
+* [Extension YAML file](https://www.dynatrace.com/support/help/shortlink/extension-yaml)
+* [Sign extensions](https://www.dynatrace.com/support/help/shortlink/sign-extension)
 
 ### Tutorial: building the custom extension for GCE Virtual Machine
 As **an example**, the guide explains how to customize `Google Compute Engine` extension. 
@@ -1063,7 +1063,7 @@ Sample dashboard for GCE:
 ####  7. Build Your developer certificate
 
 Follow the guide
-[Sign extensions](https://www.dynatrace.com/support/help/extend-dynatrace/extensions20/sign-extension) to build the developer key and **upload** the root certificate to the Dynatrace cluster
+[Sign extensions](https://www.dynatrace.com/support/help/shortlink/sign-extension) to build the developer key and **upload** the root certificate to the Dynatrace cluster
 
 Build the root certificate
 Add the root certificate to the Dynatrace credential vault 
@@ -1099,6 +1099,6 @@ You can double-check if `Google Compute Engine` dashboard included in the new ex
 #### 10. Activate configuration
 The custom extension contains metrics for `gce_instance` service and `default_metrics` feature set. You should make sure that this featureSet is activated. 
 
-Follow the guide [Set up the Dynatrace GCP metric integration on a GKE cluster](https://www.dynatrace.com/support/help/how-to-use-dynatrace/infrastructure-monitoring/cloud-platform-monitoring/google-cloud-platform-monitoring/alternative-deployment-scenarios/set-up-gcp-integration-metrics-only)
+Follow the guide [Set up the Dynatrace GCP metric integration on a GKE cluster](https://www.dynatrace.com/support/help/shortlink/metric-gke)
 
 Make sure that `gce_instance`.`default_metrics` featureSet is enabled in `values.yaml`. If not, please add it and upgrade the HELM release.

--- a/MIGRATION-V1.md
+++ b/MIGRATION-V1.md
@@ -2,20 +2,19 @@
 
 Upgrading existing `dynatrace-gcp-function` installations (either K8S or Cloud Function deployment) from 0.1.x is not supported.
 Existing old 0.1.x deployments need to be deleted and new 1.0.x installation needs to be deployed.
-New wersion (1.0.x) of `dynatrace-gcp-function` is using [Extensions 2.0](https://www.dynatrace.com/support/help/extend-dynatrace/extensions20/) and requires Dynatrace version 1.230 or higher.
-Required permissions for Dynatrace API token has changed in 1.0.x
-If you want to reuse previous Dynatrace API token in new deployment modify its permissions (see [Dynatrace documentation](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-cloud-platforms/google-cloud-platform/set-up-integration-gcp/) for details).
+New wersion (1.0.x) of `dynatrace-gcp-function` is using [Extensions 2.0](https://www.dynatrace.com/support/help/shortlink/extensions20) and requires Dynatrace version 1.230 or higher.
+Required permissions for Dynatrace API token has changed in 1.0.x - you need to create a new token (see [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/deploy-k8#api) for details).
 
 ## K8S deployment
-Uninstall old helm release and install new version as described in [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/deploy-k8#type)
+Uninstall old helm release and install new version as described in [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/deploy-k8)
 
-## Cloud Function deployment
+## Cloud Function deployment (DEPRECATED)
 Run uninstall script:
 ```shell script
 wget https://raw.githubusercontent.com/dynatrace-oss/dynatrace-gcp-function/master/scripts/uninstall.sh -O uninstall.sh ; chmod a+x uninstall.sh ; ./uninstall.sh
 ```
 Remove old configuration file (actovation-config.yaml)
-Install new `dynatrace-gcp-function` deployment following instructions in [Dynatrace documentation](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-cloud-platforms/google-cloud-platform/set-up-integration-gcp/deploy-as-gcp-function/) 
+Install new `dynatrace-gcp-function` deployment following instructions in [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/deploy-gcp) 
 
 ## Dynatrace environment cleanup
 There might be some Dynatrace dashboards and/or alerts left from previous 0.1.x installations. They need to be deleted manually.

--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@ We will provide migration guide shortly.
 If you already have previous version of `dynatrace-gcp-function` deployed, please refer to [migration guide](./MIGRATION-V1.md) before installing latest version.
 
 ## Pricing
-- Ingested metrics will consume DDUs. For more details [GCP service monitoring consumption](https://www.dynatrace.com/support/help/reference/monitoring-consumption-calculation/#expand-gcp-service-monitoring-consumption-104)
-- Ingested logs will consume DDUs. For more details [Log monitoring consumption](https://www.dynatrace.com/support/help/reference/monitoring-consumption-calculation/log-monitoring-consumption/)
+- Ingested metrics will consume DDUs. For more details [GCP service monitoring consumption](https://www.dynatrace.com/support/help/shortlink/metric-cost-calculation#calculation-details)
+- Ingested logs will consume DDUs. For more details [Log monitoring consumption](https://www.dynatrace.com/support/help/shortlink/calculate-log-consumption#how-log-monitoring-can-affect-your-ddu-consumption)
 
 ## Support
-Before you create a ticket check [troubleshooting guides](https://www.dynatrace.com/support/help/shortlink/troubleshoot-gcp) specific to your deployment.  
+Before you create a ticket check [troubleshooting guides](https://www.dynatrace.com/support/help/shortlink/deploy-k8#troubleshoot) specific to your deployment.  
 If you didn't find a solution please [contact Dynatrace support](https://www.dynatrace.com/support/contact-support/). 
 
 
 ## Additional resources
 - [Architecture overview of Kubernetes deployment](./docs/k8s.md)
-- [Monitoring multiple projects](https://www.dynatrace.com/support/help/technology-support/cloud-platforms/google-cloud-platform/monitor-gcp-services-and-logs-with-dynatrace/monitor-multiple-projects/)
+- [Monitoring multiple projects](https://www.dynatrace.com/support/help/shortlink/gcp-projects)
 - [Expand monitoring in a Kubernetes container](https://www.dynatrace.com/support/help/shortlink/expand-k8s)
-- [Self-monitoring in Google Cloud for metrics](https://www.dynatrace.com/support/help/shortlink/troubleshoot-gcp)
+- [Self-monitoring in Google Cloud for metrics](https://www.dynatrace.com/support/help/shortlink/self-mon-gcp)
 - [Self-monitoring for logs](docs/sfm_log.MD)
 - [Dynatrace Azure Log Forwarder](https://github.com/dynatrace-oss/dynatrace-azure-log-forwarder)
 - [Dynatrace AWS log forwarder](https://github.com/dynatrace-oss/dynatrace-aws-log-forwarder)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ We will provide migration guide shortly.
 If you already have previous version of `dynatrace-gcp-function` deployed, please refer to [migration guide](./MIGRATION-V1.md) before installing latest version.
 
 ## Pricing
-- Ingested metrics will consume DDUs. For more details [GCP service monitoring consumption](https://www.dynatrace.com/support/help/shortlink/metric-cost-calculation#calculation-details)
-- Ingested logs will consume DDUs. For more details [Log monitoring consumption](https://www.dynatrace.com/support/help/shortlink/calculate-log-consumption#how-log-monitoring-can-affect-your-ddu-consumption)
+- Ingested metrics will consume DDUs. For more details [GCP service monitoring consumption](https://www.dynatrace.com/support/help/shortlink/metric-cost-calculation#which-built-in-metrics-consume-ddus)
+- Ingested logs will consume DDUs. For more details [Log monitoring consumption](https://www.dynatrace.com/support/help/shortlink/calculate-log-consumption)
 
 ## Support
 Before you create a ticket check [troubleshooting guides](https://www.dynatrace.com/support/help/shortlink/deploy-k8#troubleshoot) specific to your deployment.  


### PR DESCRIPTION
Fixing links to Dynatrace documentation in markdown files.
Marking Cloud Function deployment as deprecated in MIGRATION-V1.md
Removing info about reusing Dynatrace API token in MIGRATION-V1.md
