### PR TITLE
Update values.yaml to monitor CloudSQL metrics

### DIFF
--- a/k8s/helm-chart/dynatrace-gcp-monitor/values.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/values.yaml
@@ -328,7 +328,7 @@ gcpServicesYaml: |
       allowAutodiscovery: false
       featureSets:
         - default_metrics
-      #   - postgresqlinsights
+      # - postgresqlinsights
       vars:
         filter_conditions: ""
     # Google Cloud Trace


### PR DESCRIPTION
CloudSQL metrics with Postgres services were not able to capture by Dynatrace because of the typo in the **values.yaml** code. 

There was a typo existed in *googleservices yaml*. 
- Adjusted the typo of postgresdbinsights

This changes was suggested with respect to the ticket: [415842](https://dynatrace.zendesk.com/agent/tickets/415842)