### PR TITLE
Add GCP project ID alias and corresponding test case

### DIFF
--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -43,6 +43,7 @@ GCP_MONITORING_URL = config.gcp_monitoring_url()
 DT_SECURITY_CONTEXT_VALUE = config.get_dt_security_context_value()
 METRIC_SOURCE_DIMENSION_KEY = "dt.source"
 METRIC_SOURCE_DIMENSION_VALUE = "com.dynatrace.gcp"
+RESOURCE_LABEL_ALIASES = {"project_id": "gcp.project.id"}
 
 # Retry configuration for Dynatrace ingest API
 _RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
@@ -516,6 +517,9 @@ def create_dimensions(context: MetricsContext, service_name: str, time_series: D
     resource_labels = time_series.get('resource', {}).get('labels', {})
     for short_source_label, dim_value in resource_labels.items():
         mapped_dt_dim_labels = dt_dimensions_mapping.get_dt_dimensions(f"resource.labels.{short_source_label}", short_source_label)
+        alias = RESOURCE_LABEL_ALIASES.get(short_source_label)
+        if alias:
+            mapped_dt_dim_labels = sorted({*mapped_dt_dim_labels, alias})
         for dt_dim_label in mapped_dt_dim_labels:
             dt_dimensions.append( create_dimension(dt_dim_label, dim_value, context) )
 

--- a/tests/unit/metrics_ingest_test.py
+++ b/tests/unit/metrics_ingest_test.py
@@ -92,6 +92,26 @@ def test_create_dimensions_omits_min_sample_period_override_when_not_overridden(
     assert all(d.name != "dt.min_sample_period_override" for d in dimensions)
 
 
+def test_create_dimensions_adds_gcp_project_id_alias_for_returned_resource_project_id():
+    context = LoggingContext(None)
+    service_name = "test.autodiscovered"
+    time_series = {
+        "metric": {"labels": {}},
+        "resource": {"labels": {"project_id": "test-project"}},
+        "metadata": {"systemLabels": {}, "userLabels": {}},
+    }
+
+    metric = type("MetricStub", (), {})()
+    metric.autodiscovered_metric = True
+    metric.sample_period_overridden = False
+
+    dimensions = create_dimensions(context, service_name, time_series, DtDimensionsMap(), metric)
+    dimensions_by_name = {dimension.name: dimension.value for dimension in dimensions}
+
+    assert dimensions_by_name["project_id"] == "test-project"
+    assert dimensions_by_name["gcp.project.id"] == "test-project"
+
+
 def test_create_dimensions_includes_override_for_autodiscovered_metric_via_effective_sample_period():
     context = LoggingContext(None)
     service_name = "test.autodiscovered"


### PR DESCRIPTION
This pull request introduces an alias for the `project_id` resource label, ensuring it is also available as `gcp.project.id` in Dynatrace dimensions. This improves compatibility with Dynatrace's expected dimension naming. The update is covered by a new unit test to verify the correct behavior.

**Dimension aliasing improvements:**
* Added a `RESOURCE_LABEL_ALIASES` mapping in `metric_ingest.py` to map `project_id` to `gcp.project.id`, so both dimension names are included when ingesting metrics. [[1]](diffhunk://#diff-c5626096d0344873a917f85fe0608fc810b5b6e7f86b6474ca3929cc1b328dd3R46) [[2]](diffhunk://#diff-c5626096d0344873a917f85fe0608fc810b5b6e7f86b6474ca3929cc1b328dd3R520-R522)

**Testing:**
* Added a unit test `test_create_dimensions_adds_gcp_project_id_alias_for_returned_resource_project_id` to ensure that when a `project_id` label is present, both `project_id` and `gcp.project.id` dimensions are created with the correct value.