### PR TITLE
Separate cloud_run_job from cloud_run_revision in autodiscovery 

### DIFF
--- a/k8s/helm-chart/dynatrace-gcp-monitor/values.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/values.yaml
@@ -478,6 +478,14 @@ gcpServicesYaml: |
       # minSamplePeriodOverride: 300
       vars:
         filter_conditions: ""
+    # Google Cloud Run Job
+    - service: cloud_run_job
+      allowAutodiscovery: false
+      featureSets:
+        - default_metrics
+      # minSamplePeriodOverride: 300
+      vars:
+        filter_conditions: ""
     # Google Cloud Tasks queues
     - service: cloud_tasks_queue
       allowAutodiscovery: false

--- a/src/lib/autodiscovery/config/autodiscovery-mapping.yaml
+++ b/src/lib/autodiscovery/config/autodiscovery-mapping.yaml
@@ -156,6 +156,9 @@ gcp_extension_mapping:
     feature_set: default_metrics
     monitored_resources:
     - value: cloud_run_revision
+  - service_name: cloud_run_job
+    feature_set: default_metrics
+    monitored_resources:
     - value: cloud_run_job
 - extension_name: google-cloud-storage
   services:


### PR DESCRIPTION
This pull request adds support for monitoring Google Cloud Run Jobs to the configuration files, enabling the collection of default metrics for this service. The changes ensure that Cloud Run Jobs are now included alongside other GCP services in both the Helm chart values and the autodiscovery mapping.

**Support for Google Cloud Run Jobs:**

* Added a new entry for `cloud_run_job` in the `gcpServicesYaml` section of `values.yaml`, specifying default metrics and configuration options.
* Updated `autodiscovery-mapping.yaml` to map the `cloud_run_job` service to its monitored resource and associate it with the `default_metrics` feature set.