### PR TITLE
fix: aggregate excluded cumulative dimensions

### DIFF
--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -16,7 +16,7 @@ import gzip
 import time
 from datetime import timezone, datetime, timedelta
 from http.client import InvalidURL
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Set
 
 from lib.configuration import config
 from lib.context import MetricsContext, LoggingContext, DynatraceConnectivity
@@ -332,20 +332,6 @@ async def fetch_metric(
             effective_sample_period = timedelta(seconds=linked_override)
     alignment_period = effective_sample_period if effective_sample_period is not None else metric.sample_period_seconds
 
-    # Ref: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors
-    # Combinations: https://cloud.google.com/monitoring/api/v3/kinds-and-types#kind-type-combos
-    aligner = _set_aligner(metric.google_metric_kind, metric.value_type)
-    reducer = _set_reducer(metric.google_metric_kind, metric.value_type)
-
-    params = [
-        ('filter', f'metric.type = "{metric.google_metric}" {monitoring_filter}'.strip()),
-        ('interval.startTime', start_time.isoformat() + "Z"),
-        ('interval.endTime', end_time.isoformat() + "Z"),
-        ('aggregation.alignmentPeriod', f"{alignment_period.total_seconds()}s"),
-        ('aggregation.perSeriesAligner', aligner),
-        ('aggregation.crossSeriesReducer', reducer)
-    ]
-
     if metric.autodiscovered_metric and isinstance(service, AutodiscoveryGCPService):
         service_dimensions = service.get_dimensions(metric)
         service_name = service.get_name(metric)
@@ -355,16 +341,34 @@ async def fetch_metric(
 
     all_dimensions = (service_dimensions + metric.dimensions)
     dt_dimensions_mapping = DtDimensionsMap()
+    group_by_params = []
+    excluded_source_dimensions = set()
     for dimension in all_dimensions:
         if should_exclude_dimension(dimension):
             context.log(
                 f"Skipping fetching dimension {dimension.key_for_create_entity_id} for metric {metric.google_metric}")
+            excluded_source_dimensions.add(dimension.key_for_fetch_metric)
             continue
 
         if dimension.key_for_send_to_dynatrace:
             dt_dimensions_mapping.add_label_mapping(dimension.key_for_fetch_metric, dimension.key_for_send_to_dynatrace)
 
-        params.append(('aggregation.groupByFields', dimension.key_for_fetch_metric))
+        group_by_params.append(('aggregation.groupByFields', dimension.key_for_fetch_metric))
+
+    # Ref: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors
+    # Combinations: https://cloud.google.com/monitoring/api/v3/kinds-and-types#kind-type-combos
+    aligner = _set_aligner(metric.google_metric_kind, metric.value_type)
+    reducer = _set_reducer(metric.google_metric_kind, metric.value_type, bool(excluded_source_dimensions))
+
+    params = [
+        ('filter', f'metric.type = "{metric.google_metric}" {monitoring_filter}'.strip()),
+        ('interval.startTime', start_time.isoformat() + "Z"),
+        ('interval.endTime', end_time.isoformat() + "Z"),
+        ('aggregation.alignmentPeriod', f"{alignment_period.total_seconds()}s"),
+        ('aggregation.perSeriesAligner', aligner),
+        ('aggregation.crossSeriesReducer', reducer)
+    ]
+    params.extend(group_by_params)
 
     for label in grouping.split(","):
         if label == NO_GROUPING_CATEGORY:
@@ -390,7 +394,10 @@ async def fetch_metric(
 
         for single_time_series in page['timeSeries']:
             typed_value_key = _extract_typed_value_key(single_time_series)
-            dimensions = create_dimensions(context, service_name, single_time_series, dt_dimensions_mapping, metric, effective_sample_period)
+            dimensions = create_dimensions(
+                context, service_name, single_time_series, dt_dimensions_mapping, metric,
+                effective_sample_period, excluded_source_dimensions
+            )
             entity_id = create_entity_id(service_name, service_dimensions, single_time_series)
 
             for point in single_time_series['points']:
@@ -420,11 +427,14 @@ def _set_aligner(metric_kind, value_type):
     return aligner
 
 
-def _set_reducer(metric_kind, value_type):
+def _set_reducer(metric_kind, value_type, aggregate_excluded_dimensions=False):
     reducer = 'REDUCE_SUM'
 
     if metric_kind.lower().startswith('cumulative'):
-        reducer = 'REDUCE_NONE'
+        if aggregate_excluded_dimensions and value_type.lower() in ('int64', 'double', 'distribution'):
+            reducer = 'REDUCE_SUM'
+        else:
+            reducer = 'REDUCE_NONE'
     elif metric_kind.lower().startswith('gauge') and (value_type.lower() == 'int64' or value_type.lower() == 'double'):
         reducer = 'REDUCE_MEAN'
 
@@ -495,7 +505,16 @@ def create_dimension(name: str, value: Any, context: LoggingContext = LoggingCon
 
 
     # "gcp.resource.type" is required to easily differentiate services with the same metric set
-def create_dimensions(context: MetricsContext, service_name: str, time_series: Dict, dt_dimensions_mapping: DtDimensionsMap, metric: Metric, effective_sample_period: Optional[timedelta] = None) -> List[DimensionValue]:
+def create_dimensions(
+        context: MetricsContext,
+        service_name: str,
+        time_series: Dict,
+        dt_dimensions_mapping: DtDimensionsMap,
+        metric: Metric,
+        effective_sample_period: Optional[timedelta] = None,
+        excluded_source_dimensions: Optional[Set[str]] = None
+) -> List[DimensionValue]:
+    excluded_source_dimensions = excluded_source_dimensions or set()
     # e.g. internal_tcp_lb_rule and internal_udp_lb_rule
     dt_dimensions = [create_dimension("gcp.resource.type", service_name, context)]
 
@@ -510,13 +529,19 @@ def create_dimensions(context: MetricsContext, service_name: str, time_series: D
 
     metric_labels = time_series.get('metric', {}).get('labels', {})
     for short_source_label, dim_value in metric_labels.items():
-        mapped_dt_dim_labels = dt_dimensions_mapping.get_dt_dimensions(f"metric.labels.{short_source_label}", short_source_label)
+        source_dimension = f"metric.labels.{short_source_label}"
+        if source_dimension in excluded_source_dimensions:
+            continue
+        mapped_dt_dim_labels = dt_dimensions_mapping.get_dt_dimensions(source_dimension, short_source_label)
         for dt_dim_label in mapped_dt_dim_labels:
             dt_dimensions.append( create_dimension(dt_dim_label, dim_value, context) )
 
     resource_labels = time_series.get('resource', {}).get('labels', {})
     for short_source_label, dim_value in resource_labels.items():
-        mapped_dt_dim_labels = dt_dimensions_mapping.get_dt_dimensions(f"resource.labels.{short_source_label}", short_source_label)
+        source_dimension = f"resource.labels.{short_source_label}"
+        if source_dimension in excluded_source_dimensions:
+            continue
+        mapped_dt_dim_labels = dt_dimensions_mapping.get_dt_dimensions(source_dimension, short_source_label)
         alias = RESOURCE_LABEL_ALIASES.get(short_source_label)
         if alias:
             mapped_dt_dim_labels = sorted({*mapped_dt_dim_labels, alias})
@@ -525,12 +550,17 @@ def create_dimensions(context: MetricsContext, service_name: str, time_series: D
 
     system_labels = time_series.get('metadata', {}).get('systemLabels', {})
     for short_source_label, dim_value in system_labels.items():
-        mapped_dt_dim_labels = dt_dimensions_mapping.get_dt_dimensions(f"metadata.systemLabels.{short_source_label}", short_source_label)
+        source_dimension = f"metadata.systemLabels.{short_source_label}"
+        if source_dimension in excluded_source_dimensions:
+            continue
+        mapped_dt_dim_labels = dt_dimensions_mapping.get_dt_dimensions(source_dimension, short_source_label)
         for dt_dim_label in mapped_dt_dim_labels:
             dt_dimensions.append( create_dimension(dt_dim_label, dim_value, context) )
 
     user_labels = time_series.get('metadata', {}).get('userLabels', {})
     for dim_label, dim_value in user_labels.items():
+        if f"metadata.userLabels.{dim_label}" in excluded_source_dimensions:
+            continue
         dt_dimensions.append(create_dimension(dim_label, dim_value, context))
 
     return dt_dimensions

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -504,6 +504,41 @@ def create_dimension(name: str, value: Any, context: LoggingContext = LoggingCon
     return DimensionValue(name, string_value)
 
 
+def _append_mapped_label_dimensions(
+        context: MetricsContext,
+        dt_dimensions: List[DimensionValue],
+        labels: Dict,
+        source_prefix: str,
+        dt_dimensions_mapping: DtDimensionsMap,
+        excluded_source_dimensions: Set[str],
+        aliases: Optional[Dict[str, str]] = None,
+):
+    for short_source_label, dim_value in labels.items():
+        source_dimension = f"{source_prefix}.{short_source_label}"
+        if source_dimension in excluded_source_dimensions:
+            continue
+
+        mapped_dt_dim_labels = dt_dimensions_mapping.get_dt_dimensions(source_dimension, short_source_label)
+        alias = aliases.get(short_source_label) if aliases else None
+        if alias:
+            mapped_dt_dim_labels = sorted({*mapped_dt_dim_labels, alias})
+
+        for dt_dim_label in mapped_dt_dim_labels:
+            dt_dimensions.append(create_dimension(dt_dim_label, dim_value, context))
+
+
+def _append_user_label_dimensions(
+        context: MetricsContext,
+        dt_dimensions: List[DimensionValue],
+        labels: Dict,
+        excluded_source_dimensions: Set[str],
+):
+    for dim_label, dim_value in labels.items():
+        if f"metadata.user_labels.{dim_label}" in excluded_source_dimensions:
+            continue
+        dt_dimensions.append(create_dimension(dim_label, dim_value, context))
+
+
 # "gcp.resource.type" is required to easily differentiate services with the same metric set
 def create_dimensions(
         context: MetricsContext,
@@ -527,41 +562,21 @@ def create_dimensions(
     elif getattr(metric, "sample_period_overridden", False):
         dt_dimensions.append(create_dimension("dt.min_sample_period_override", str(int(metric.sample_period_seconds.total_seconds())), context))
 
-    metric_labels = time_series.get('metric', {}).get('labels', {})
-    for short_source_label, dim_value in metric_labels.items():
-        source_dimension = f"metric.labels.{short_source_label}"
-        if source_dimension in excluded_source_dimensions:
-            continue
-        mapped_dt_dim_labels = dt_dimensions_mapping.get_dt_dimensions(source_dimension, short_source_label)
-        for dt_dim_label in mapped_dt_dim_labels:
-            dt_dimensions.append( create_dimension(dt_dim_label, dim_value, context) )
-
-    resource_labels = time_series.get('resource', {}).get('labels', {})
-    for short_source_label, dim_value in resource_labels.items():
-        source_dimension = f"resource.labels.{short_source_label}"
-        if source_dimension in excluded_source_dimensions:
-            continue
-        mapped_dt_dim_labels = dt_dimensions_mapping.get_dt_dimensions(source_dimension, short_source_label)
-        alias = RESOURCE_LABEL_ALIASES.get(short_source_label)
-        if alias:
-            mapped_dt_dim_labels = sorted({*mapped_dt_dim_labels, alias})
-        for dt_dim_label in mapped_dt_dim_labels:
-            dt_dimensions.append( create_dimension(dt_dim_label, dim_value, context) )
-
-    system_labels = time_series.get('metadata', {}).get('systemLabels', {})
-    for short_source_label, dim_value in system_labels.items():
-        source_dimension = f"metadata.system_labels.{short_source_label}"
-        if source_dimension in excluded_source_dimensions:
-            continue
-        mapped_dt_dim_labels = dt_dimensions_mapping.get_dt_dimensions(source_dimension, short_source_label)
-        for dt_dim_label in mapped_dt_dim_labels:
-            dt_dimensions.append( create_dimension(dt_dim_label, dim_value, context) )
-
-    user_labels = time_series.get('metadata', {}).get('userLabels', {})
-    for dim_label, dim_value in user_labels.items():
-        if f"metadata.user_labels.{dim_label}" in excluded_source_dimensions:
-            continue
-        dt_dimensions.append(create_dimension(dim_label, dim_value, context))
+    _append_mapped_label_dimensions(
+        context, dt_dimensions, time_series.get('metric', {}).get('labels', {}),
+        "metric.labels", dt_dimensions_mapping, excluded_source_dimensions
+    )
+    _append_mapped_label_dimensions(
+        context, dt_dimensions, time_series.get('resource', {}).get('labels', {}),
+        "resource.labels", dt_dimensions_mapping, excluded_source_dimensions, RESOURCE_LABEL_ALIASES
+    )
+    _append_mapped_label_dimensions(
+        context, dt_dimensions, time_series.get('metadata', {}).get('systemLabels', {}),
+        "metadata.system_labels", dt_dimensions_mapping, excluded_source_dimensions
+    )
+    _append_user_label_dimensions(
+        context, dt_dimensions, time_series.get('metadata', {}).get('userLabels', {}), excluded_source_dimensions
+    )
 
     return dt_dimensions
 

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -504,7 +504,7 @@ def create_dimension(name: str, value: Any, context: LoggingContext = LoggingCon
     return DimensionValue(name, string_value)
 
 
-    # "gcp.resource.type" is required to easily differentiate services with the same metric set
+# "gcp.resource.type" is required to easily differentiate services with the same metric set
 def create_dimensions(
         context: MetricsContext,
         service_name: str,

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -550,7 +550,7 @@ def create_dimensions(
 
     system_labels = time_series.get('metadata', {}).get('systemLabels', {})
     for short_source_label, dim_value in system_labels.items():
-        source_dimension = f"metadata.systemLabels.{short_source_label}"
+        source_dimension = f"metadata.system_labels.{short_source_label}"
         if source_dimension in excluded_source_dimensions:
             continue
         mapped_dt_dim_labels = dt_dimensions_mapping.get_dt_dimensions(source_dimension, short_source_label)
@@ -559,7 +559,7 @@ def create_dimensions(
 
     user_labels = time_series.get('metadata', {}).get('userLabels', {})
     for dim_label, dim_value in user_labels.items():
-        if f"metadata.userLabels.{dim_label}" in excluded_source_dimensions:
+        if f"metadata.user_labels.{dim_label}" in excluded_source_dimensions:
             continue
         dt_dimensions.append(create_dimension(dim_label, dim_value, context))
 

--- a/tests/unit/metrics_ingest_test.py
+++ b/tests/unit/metrics_ingest_test.py
@@ -165,6 +165,37 @@ def test_create_dimensions_omits_excluded_returned_metric_label():
     assert dimensions_by_name["query_hash"] == "abc"
 
 
+def test_create_dimensions_omits_excluded_metadata_labels():
+    context = LoggingContext(None)
+    metric = type("MetricStub", (), {})()
+    metric.autodiscovered_metric = False
+    metric.sample_period_overridden = False
+
+    time_series = {
+        "metric": {"labels": {}},
+        "resource": {"labels": {}},
+        "metadata": {
+            "systemLabels": {"machine_type": "n2-standard-4", "location": "us-east1"},
+            "userLabels": {"team": "payments", "env": "prod"},
+        },
+    }
+
+    dimensions = create_dimensions(
+        context,
+        "gce_instance",
+        time_series,
+        DtDimensionsMap(),
+        metric,
+        excluded_source_dimensions={"metadata.system_labels.machine_type", "metadata.user_labels.team"},
+    )
+
+    dimensions_by_name = {dimension.name: dimension.value for dimension in dimensions}
+    assert "machine_type" not in dimensions_by_name
+    assert "team" not in dimensions_by_name
+    assert dimensions_by_name["location"] == "us-east1"
+    assert dimensions_by_name["env"] == "prod"
+
+
 def test_cumulative_reducer_uses_sum_only_when_dimensions_are_excluded():
     assert _set_reducer("CUMULATIVE", "INT64") == "REDUCE_NONE"
     assert _set_reducer("CUMULATIVE", "INT64", aggregate_excluded_dimensions=True) == "REDUCE_SUM"

--- a/tests/unit/metrics_ingest_test.py
+++ b/tests/unit/metrics_ingest_test.py
@@ -12,10 +12,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from datetime import timedelta
+from datetime import datetime, timedelta
+
+import pytest
 
 from lib.entities.model import CdProperty
 from lib.metric_ingest import *
+from lib.metric_ingest import _set_reducer
 from lib.topology.topology import build_entity_id_map
 
 
@@ -134,6 +137,84 @@ def test_create_dimensions_includes_override_for_autodiscovered_metric_via_effec
     override_dims = [d for d in dimensions if d.name == "dt.min_sample_period_override"]
     assert len(override_dims) == 1
     assert override_dims[0].value == "300"
+
+
+def test_create_dimensions_omits_excluded_returned_metric_label():
+    context = LoggingContext(None)
+    metric = type("MetricStub", (), {})()
+    metric.autodiscovered_metric = False
+    metric.sample_period_overridden = False
+
+    time_series = {
+        "metric": {"labels": {"querystring": "SELECT 1", "query_hash": "abc"}},
+        "resource": {"labels": {"project_id": "test-project"}},
+        "metadata": {"systemLabels": {}, "userLabels": {}},
+    }
+
+    dimensions = create_dimensions(
+        context,
+        "cloudsql_database",
+        time_series,
+        DtDimensionsMap(),
+        metric,
+        excluded_source_dimensions={"metric.labels.querystring"},
+    )
+
+    dimensions_by_name = {dimension.name: dimension.value for dimension in dimensions}
+    assert "querystring" not in dimensions_by_name
+    assert dimensions_by_name["query_hash"] == "abc"
+
+
+def test_cumulative_reducer_uses_sum_only_when_dimensions_are_excluded():
+    assert _set_reducer("CUMULATIVE", "INT64") == "REDUCE_NONE"
+    assert _set_reducer("CUMULATIVE", "INT64", aggregate_excluded_dimensions=True) == "REDUCE_SUM"
+    assert _set_reducer("CUMULATIVE", "DISTRIBUTION", aggregate_excluded_dimensions=True) == "REDUCE_SUM"
+
+
+class _FakeGcpResponse:
+    async def json(self):
+        return {}
+
+
+class _FakeGcpSession:
+    def __init__(self):
+        self.params = None
+
+    async def request(self, method, url, params, headers):
+        self.params = list(params)
+        return _FakeGcpResponse()
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_aggregates_cumulative_metric_when_dimension_excluded():
+    gcp_session = _FakeGcpSession()
+    context = MetricsContext(gcp_session, None, "owner", "token", datetime.utcnow(), 60, "", "", False, False, None)
+    service = GCPService(service="cloudsql_database", dimensions=[], metrics=[])
+    metric = Metric(
+        name="Per query execution time",
+        value="metric:cloudsql.googleapis.com/database/postgresql/insights/perquery/execution_time",
+        key="cloud.gcp.cloudsql_googleapis_com.database.postgresql.insights.perquery.execution_time.count",
+        type="count",
+        gcpOptions={"ingestDelay": 0, "samplePeriod": 60, "valueType": "INT64", "metricKind": "CUMULATIVE"},
+        dimensions=[
+            {"key": "querystring", "value": "label:metric.labels.querystring"},
+            {"key": "query_hash", "value": "label:metric.labels.query_hash"},
+        ],
+    )
+
+    await fetch_metric(
+        context,
+        "test-project",
+        service,
+        metric,
+        [{"metric": metric.google_metric, "dimensions": {"querystring"}}],
+        NO_GROUPING_CATEGORY,
+    )
+
+    assert ("aggregation.perSeriesAligner", "ALIGN_DELTA") in gcp_session.params
+    assert ("aggregation.crossSeriesReducer", "REDUCE_SUM") in gcp_session.params
+    assert ("aggregation.groupByFields", "metric.labels.querystring") not in gcp_session.params
+    assert ("aggregation.groupByFields", "metric.labels.query_hash") in gcp_session.params
 
 
 def test_flatten_and_enrich_metric_results_all_additional_dimensions():

--- a/tests/unit/metrics_ingest_test.py
+++ b/tests/unit/metrics_ingest_test.py
@@ -12,7 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from datetime import datetime, timedelta
+import asyncio
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -204,6 +205,7 @@ def test_cumulative_reducer_uses_sum_only_when_dimensions_are_excluded():
 
 class _FakeGcpResponse:
     async def json(self):
+        await asyncio.sleep(0)
         return {}
 
 
@@ -211,7 +213,8 @@ class _FakeGcpSession:
     def __init__(self):
         self.params = None
 
-    async def request(self, method, url, params, headers):
+    async def request(self, _method, _url, params, _headers):
+        await asyncio.sleep(0)
         self.params = list(params)
         return _FakeGcpResponse()
 
@@ -219,7 +222,7 @@ class _FakeGcpSession:
 @pytest.mark.asyncio
 async def test_fetch_metric_aggregates_cumulative_metric_when_dimension_excluded():
     gcp_session = _FakeGcpSession()
-    context = MetricsContext(gcp_session, None, "owner", "token", datetime.utcnow(), 60, "", "", False, False, None)
+    context = MetricsContext(gcp_session, None, "owner", "token", datetime.now(timezone.utc), 60, "", "", False, False, None)
     service = GCPService(service="cloudsql_database", dimensions=[], metrics=[])
     metric = Metric(
         name="Per query execution time",
@@ -249,7 +252,7 @@ async def test_fetch_metric_aggregates_cumulative_metric_when_dimension_excluded
 
 
 def test_flatten_and_enrich_metric_results_all_additional_dimensions():
-    context_mock = MetricsContext(None, None, "", "", datetime.utcnow(), 0, "", "", False, False, None)
+    context_mock = MetricsContext(None, None, "", "", datetime.now(timezone.utc), 0, "", "", False, False, None)
     metric_results = [[IngestLine("entity_id", "m1", "count", 1, 10000, [])]]
     entity_id_map = build_entity_id_map([[Entity("entity_id", "", "", ip_addresses=["1.1.1.1", "0.0.0.0"], listen_ports=[],
                                          favicon_url="", dtype="", properties=[CdProperty("Example property", "example_value")],

--- a/tests/unit/metrics_ingest_test.py
+++ b/tests/unit/metrics_ingest_test.py
@@ -213,8 +213,9 @@ class _FakeGcpSession:
     def __init__(self):
         self.params = None
 
-    async def request(self, _method, _url, params, _headers):
+    async def request(self, _method, url, params, headers):
         await asyncio.sleep(0)
+        _ = (url, headers)
         self.params = list(params)
         return _FakeGcpResponse()
 


### PR DESCRIPTION
## Summary
- aggregate cumulative metrics with excluded dimensions so omitted labels are removed by GCP
- defensively skip excluded labels during Dynatrace dimension creation
- add unit coverage for cumulative dimension exclusion

