### PR TITLE
Fix/specific exclusion matching

### DIFF
--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -74,10 +74,10 @@ def should_exclude_metric(metric_name: str, excluded_metrics_and_dimensions: lis
 
 
 def should_exclude_dimension(
-        metric_name: str,
-        dimension: Dimension,
-        excluded_metrics_and_dimensions: list,
-        found_excluded_metric: Optional[dict] = None,
+    metric_name: str,
+    dimension: Dimension,
+    excluded_metrics_and_dimensions: list,
+    found_excluded_metric: Optional[dict] = None,
 ):
     if found_excluded_metric is None:
         found_excluded_metric = find_excluded_metric(metric_name, excluded_metrics_and_dimensions)

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -73,8 +73,14 @@ def should_exclude_metric(metric_name: str, excluded_metrics_and_dimensions: lis
     return bool(found_excluded_metric and not found_excluded_metric.get("dimensions"))
 
 
-def should_exclude_dimension(metric_name: str, dimension: Dimension, excluded_metrics_and_dimensions: list):
-    found_excluded_metric = find_excluded_metric(metric_name, excluded_metrics_and_dimensions)
+def should_exclude_dimension(
+        metric_name: str,
+        dimension: Dimension,
+        excluded_metrics_and_dimensions: list,
+        found_excluded_metric: Optional[dict] = None,
+):
+    if found_excluded_metric is None:
+        found_excluded_metric = find_excluded_metric(metric_name, excluded_metrics_and_dimensions)
 
     if not found_excluded_metric:
         return False
@@ -359,8 +365,11 @@ async def fetch_metric(
     dt_dimensions_mapping = DtDimensionsMap()
     group_by_params = []
     excluded_source_dimensions = set()
+    found_excluded_metric = find_excluded_metric(metric.google_metric, excluded_metrics_and_dimensions)
     for dimension in all_dimensions:
-        if should_exclude_dimension(metric.google_metric, dimension, excluded_metrics_and_dimensions):
+        if should_exclude_dimension(
+                metric.google_metric, dimension, excluded_metrics_and_dimensions, found_excluded_metric
+        ):
             context.log(
                 f"Skipping fetching dimension {dimension.key_for_create_entity_id} for metric {metric.google_metric}")
             excluded_source_dimensions.add(dimension.key_for_fetch_metric)

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -53,12 +53,19 @@ _MAX_RETRY_AFTER_S = 10.0
 
 
 def find_excluded_metric(metric_name: str, excluded_metrics_and_dimensions: list):
+    def metric_prefix(excluded_metric):
+        if not isinstance(excluded_metric, dict):
+            return None
+
+        prefix = excluded_metric.get("metric")
+        return prefix if isinstance(prefix, str) and prefix else None
+
     matching_metrics = [
         excluded_metric
         for excluded_metric in excluded_metrics_and_dimensions
-        if metric_name.startswith(excluded_metric.get("metric", ""))
+        if (prefix := metric_prefix(excluded_metric)) and metric_name.startswith(prefix)
     ]
-    return max(matching_metrics, key=lambda excluded_metric: len(excluded_metric.get("metric", "")), default=None)
+    return max(matching_metrics, key=lambda excluded_metric: len(metric_prefix(excluded_metric)), default=None)
 
 
 def should_exclude_metric(metric_name: str, excluded_metrics_and_dimensions: list):

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -61,11 +61,12 @@ def find_excluded_metric(metric_name: str, excluded_metrics_and_dimensions: list
         return prefix if isinstance(prefix, str) and prefix else None
 
     matching_metrics = [
-        excluded_metric
+        (prefix, excluded_metric)
         for excluded_metric in excluded_metrics_and_dimensions
         if (prefix := metric_prefix(excluded_metric)) and metric_name.startswith(prefix)
     ]
-    return max(matching_metrics, key=lambda excluded_metric: len(metric_prefix(excluded_metric)), default=None)
+    result = max(matching_metrics, key=lambda item: len(item[0]), default=None)
+    return result[1] if result is not None else None
 
 
 def should_exclude_metric(metric_name: str, excluded_metrics_and_dimensions: list):

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -51,6 +51,31 @@ _MAX_PUSH_RETRIES = 3
 _INITIAL_RETRY_DELAY_S = 1.0
 _MAX_RETRY_AFTER_S = 10.0
 
+
+def find_excluded_metric(metric_name: str, excluded_metrics_and_dimensions: list):
+    matching_metrics = [
+        excluded_metric
+        for excluded_metric in excluded_metrics_and_dimensions
+        if metric_name.startswith(excluded_metric.get("metric", ""))
+    ]
+    return max(matching_metrics, key=lambda excluded_metric: len(excluded_metric.get("metric", "")), default=None)
+
+
+def should_exclude_metric(metric_name: str, excluded_metrics_and_dimensions: list):
+    found_excluded_metric = find_excluded_metric(metric_name, excluded_metrics_and_dimensions)
+    return bool(found_excluded_metric and not found_excluded_metric.get("dimensions"))
+
+
+def should_exclude_dimension(metric_name: str, dimension: Dimension, excluded_metrics_and_dimensions: list):
+    found_excluded_metric = find_excluded_metric(metric_name, excluded_metrics_and_dimensions)
+
+    if not found_excluded_metric:
+        return False
+
+    dimension_key = dimension.key_for_fetch_metric
+    return dimension_key[dimension_key.rfind(".") + 1:] in found_excluded_metric.get("dimensions", [])
+
+
 async def push_ingest_lines(context: MetricsContext, project_id: str, fetch_metric_results: List[IngestLine]):
     if context.dynatrace_connectivity != DynatraceConnectivity.Ok:
         context.log(project_id, f"Skipping push due to detected connectivity error")
@@ -297,22 +322,6 @@ async def fetch_metric(
         excluded_metrics_and_dimensions: list,
         grouping: str
 ) -> List[IngestLine]:
-    def should_exclude_dimension(dimension: Dimension):
-        found_excluded_metric = None
-
-        for excluded_metric in excluded_metrics_and_dimensions:
-            if metric.google_metric.startswith(excluded_metric.get("metric")):
-                found_excluded_metric = excluded_metric
-                break
-
-        if not found_excluded_metric:
-            return False
-
-        dimension_key = dimension.key_for_fetch_metric
-        has_dimension_key = dimension_key[dimension_key.rfind(".") + 1:] in found_excluded_metric.get("dimensions", [])
-
-        return has_dimension_key
-
     end_time = (context.execution_time - metric.ingest_delay)
     start_time = (end_time - context.execution_interval)
 
@@ -344,7 +353,7 @@ async def fetch_metric(
     group_by_params = []
     excluded_source_dimensions = set()
     for dimension in all_dimensions:
-        if should_exclude_dimension(dimension):
+        if should_exclude_dimension(metric.google_metric, dimension, excluded_metrics_and_dimensions):
             context.log(
                 f"Skipping fetching dimension {dimension.key_for_create_entity_id} for metric {metric.google_metric}")
             excluded_source_dimensions.add(dimension.key_for_fetch_metric)

--- a/src/main.py
+++ b/src/main.py
@@ -28,7 +28,7 @@ from lib.credentials import create_token, fetch_dynatrace_api_key, fetch_dynatra
 from lib.entities.model import Entity
 from lib.fast_check import check_dynatrace, check_version
 from lib.gcp_apis import get_disabled_projects_and_disabled_apis_by_project_id
-from lib.metric_ingest import fetch_metric, push_ingest_lines, flatten_and_enrich_metric_results
+from lib.metric_ingest import fetch_metric, push_ingest_lines, flatten_and_enrich_metric_results, should_exclude_metric
 from lib.metrics import GCPService, Metric, IngestLine, AutodiscoveryGCPService
 from lib.self_monitoring import log_self_monitoring_metrics, sfm_push_metrics, sfm_create_descriptors_if_missing
 from lib.sfm.for_metrics.metrics_definitions import SfmKeys
@@ -270,16 +270,6 @@ async def fetch_ingest_lines_task(context: MetricsContext, project_id: str, serv
         f"interval={interval_info}"
     )
 
-    def should_exclude_metric(metric: Metric):
-        found_excluded_metric = None
-
-        for excluded_metric in excluded_metrics_and_dimensions:
-            if metric.google_metric.startswith(excluded_metric.get("metric")):
-                found_excluded_metric = excluded_metric
-                break
-
-        return found_excluded_metric and not found_excluded_metric.get("dimensions")
-
     def set_groupings(service: GCPService, metric: Optional[Metric] = None):
         service_name = service.name
         if metric and metric.autodiscovered_metric and isinstance(service, AutodiscoveryGCPService):
@@ -330,7 +320,7 @@ async def fetch_ingest_lines_task(context: MetricsContext, project_id: str, serv
         for metric in service.metrics:
             labels_groupings = set_groupings(service, metric)
             for grouping in labels_groupings:
-                if should_exclude_metric(metric):
+                if should_exclude_metric(metric.google_metric, excluded_metrics_and_dimensions):
                     context.log(f"Skipping fetching all the data for the metric {metric.google_metric}")
                     continue
 

--- a/tests/unit/metrics_ingest_test.py
+++ b/tests/unit/metrics_ingest_test.py
@@ -19,7 +19,7 @@ import pytest
 
 from lib.entities.model import CdProperty
 from lib.metric_ingest import *
-from lib.metric_ingest import _set_reducer, should_exclude_dimension, should_exclude_metric
+from lib.metric_ingest import _set_reducer
 from lib.topology.topology import build_entity_id_map
 
 

--- a/tests/unit/metrics_ingest_test.py
+++ b/tests/unit/metrics_ingest_test.py
@@ -225,20 +225,24 @@ def test_exclusion_uses_most_specific_metric_match_for_dimension_skip():
 
 
 class _FakeGcpResponse:
+    def __init__(self, body=None):
+        self.body = body or {}
+
     async def json(self):
         await asyncio.sleep(0)
-        return {}
+        return self.body
 
 
 class _FakeGcpSession:
-    def __init__(self):
+    def __init__(self, response_body=None):
         self.params = None
+        self.response_body = response_body
 
     async def request(self, _method, url, params, headers):
         await asyncio.sleep(0)
         _ = (url, headers)
         self.params = list(params)
-        return _FakeGcpResponse()
+        return _FakeGcpResponse(self.response_body)
 
 
 @pytest.mark.asyncio
@@ -269,6 +273,69 @@ async def test_fetch_metric_aggregates_cumulative_metric_when_dimension_excluded
 
     assert ("aggregation.perSeriesAligner", "ALIGN_DELTA") in gcp_session.params
     assert ("aggregation.crossSeriesReducer", "REDUCE_SUM") in gcp_session.params
+    assert ("aggregation.groupByFields", "metric.labels.querystring") not in gcp_session.params
+    assert ("aggregation.groupByFields", "metric.labels.query_hash") in gcp_session.params
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_keeps_metric_when_specific_dimension_exclusion_overlaps_broad_exclusion():
+    metric_name = "cloudsql.googleapis.com/database/postgresql/insights/perquery/execution_time"
+    gcp_session = _FakeGcpSession(
+        {
+            "timeSeries": [
+                {
+                    "valueType": "INT64",
+                    "metric": {
+                        "labels": {
+                            "querystring": "SELECT 1",
+                            "query_hash": "abc123",
+                        }
+                    },
+                    "resource": {"labels": {}},
+                    "metadata": {"systemLabels": {}, "userLabels": {}},
+                    "points": [
+                        {
+                            "interval": {"endTime": "2026-07-08T17:54:00Z"},
+                            "value": {"int64Value": 42},
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    context = MetricsContext(gcp_session, None, "owner", "token", datetime.now(timezone.utc), 60, "", "", False, False, None)
+    service = GCPService(service="cloudsql_database", dimensions=[], metrics=[])
+    metric = Metric(
+        name="Per query execution time",
+        value=f"metric:{metric_name}",
+        key="cloud.gcp.cloudsql_googleapis_com.database.postgresql.insights.perquery.execution_time.count",
+        type="count",
+        gcpOptions={"ingestDelay": 0, "samplePeriod": 60, "valueType": "INT64", "metricKind": "CUMULATIVE"},
+        dimensions=[
+            {"key": "querystring", "value": "label:metric.labels.querystring"},
+            {"key": "query_hash", "value": "label:metric.labels.query_hash"},
+        ],
+    )
+
+    lines = await fetch_metric(
+        context,
+        "test-project",
+        service,
+        metric,
+        [
+            {"metric": "cloudsql.googleapis.com/database/postgresql/insights/perquery/"},
+            {"metric": metric_name, "dimensions": {"querystring"}},
+        ],
+        NO_GROUPING_CATEGORY,
+    )
+
+    assert len(lines) == 1
+    assert lines[0].metric_name == "cloud.gcp.cloudsql_googleapis_com.database.postgresql.insights.perquery.execution_time.count"
+    assert lines[0].value == 42
+
+    dimensions_by_name = {dimension.name: dimension.value for dimension in lines[0].dimension_values}
+    assert "querystring" not in dimensions_by_name
+    assert dimensions_by_name["query_hash"] == "abc123"
     assert ("aggregation.groupByFields", "metric.labels.querystring") not in gcp_session.params
     assert ("aggregation.groupByFields", "metric.labels.query_hash") in gcp_session.params
 

--- a/tests/unit/metrics_ingest_test.py
+++ b/tests/unit/metrics_ingest_test.py
@@ -19,7 +19,7 @@ import pytest
 
 from lib.entities.model import CdProperty
 from lib.metric_ingest import *
-from lib.metric_ingest import _set_reducer
+from lib.metric_ingest import _set_reducer, should_exclude_dimension, should_exclude_metric
 from lib.topology.topology import build_entity_id_map
 
 
@@ -201,6 +201,27 @@ def test_cumulative_reducer_uses_sum_only_when_dimensions_are_excluded():
     assert _set_reducer("CUMULATIVE", "INT64") == "REDUCE_NONE"
     assert _set_reducer("CUMULATIVE", "INT64", aggregate_excluded_dimensions=True) == "REDUCE_SUM"
     assert _set_reducer("CUMULATIVE", "DISTRIBUTION", aggregate_excluded_dimensions=True) == "REDUCE_SUM"
+
+
+def test_exclusion_uses_most_specific_metric_match_for_full_metric_skip():
+    metric_name = "cloudsql.googleapis.com/database/postgresql/insights/perquery/execution_time"
+    excluded_metrics = [
+        {"metric": "cloudsql.googleapis.com/database/postgresql/insights/perquery/"},
+        {"metric": metric_name, "dimensions": {"querystring"}},
+    ]
+
+    assert should_exclude_metric(metric_name, excluded_metrics) is False
+
+
+def test_exclusion_uses_most_specific_metric_match_for_dimension_skip():
+    metric_name = "cloudsql.googleapis.com/database/postgresql/insights/perquery/execution_time"
+    dimension = Dimension(key="querystring", value="label:metric.labels.querystring")
+    excluded_metrics = [
+        {"metric": "cloudsql.googleapis.com/database/postgresql/insights/perquery/"},
+        {"metric": metric_name, "dimensions": {"querystring"}},
+    ]
+
+    assert should_exclude_dimension(metric_name, dimension, excluded_metrics) is True
 
 
 class _FakeGcpResponse:

--- a/tests/unit/metrics_ingest_test.py
+++ b/tests/unit/metrics_ingest_test.py
@@ -23,6 +23,18 @@ from lib.metric_ingest import _set_reducer, should_exclude_dimension, should_exc
 from lib.topology.topology import build_entity_id_map
 
 
+QUERYSTRING_DIMENSION = "querystring"
+QUERYSTRING_FETCH_KEY = "metric.labels.querystring"
+QUERYSTRING_LABEL_VALUE = f"label:{QUERYSTRING_FETCH_KEY}"
+QUERY_HASH_DIMENSION = "query_hash"
+QUERY_HASH_FETCH_KEY = "metric.labels.query_hash"
+QUERY_HASH_LABEL_VALUE = f"label:{QUERY_HASH_FETCH_KEY}"
+PERQUERY_EXECUTION_TIME_METRIC = "cloudsql.googleapis.com/database/postgresql/insights/perquery/execution_time"
+PERQUERY_METRIC_PREFIX = "cloudsql.googleapis.com/database/postgresql/insights/perquery/"
+PERQUERY_EXECUTION_TIME_DT_METRIC = "cloud.gcp.cloudsql_googleapis_com.database.postgresql.insights.perquery.execution_time.count"
+GROUP_BY_FIELDS_PARAM = "aggregation.groupByFields"
+
+
 def test_create_dimension_correct_values():
     name = "n" * (MAX_DIMENSION_NAME_LENGTH - 1)
     value = "v" * (MAX_DIMENSION_VALUE_LENGTH - 1)
@@ -44,7 +56,7 @@ def test_create_dimension_too_long_dimension():
 
 
 def test_create_dimension_escapes_quotes_and_removes_control_chars():
-    name = "querystring"
+    name = QUERYSTRING_DIMENSION
     value = '"C:\\Program Files\\Foo\\bar.exe" -flag\nnext'
 
     dimension_value = create_dimension(name, value)
@@ -147,7 +159,7 @@ def test_create_dimensions_omits_excluded_returned_metric_label():
     metric.sample_period_overridden = False
 
     time_series = {
-        "metric": {"labels": {"querystring": "SELECT 1", "query_hash": "abc"}},
+        "metric": {"labels": {QUERYSTRING_DIMENSION: "SELECT 1", QUERY_HASH_DIMENSION: "abc"}},
         "resource": {"labels": {"project_id": "test-project"}},
         "metadata": {"systemLabels": {}, "userLabels": {}},
     }
@@ -158,12 +170,12 @@ def test_create_dimensions_omits_excluded_returned_metric_label():
         time_series,
         DtDimensionsMap(),
         metric,
-        excluded_source_dimensions={"metric.labels.querystring"},
+        excluded_source_dimensions={QUERYSTRING_FETCH_KEY},
     )
 
     dimensions_by_name = {dimension.name: dimension.value for dimension in dimensions}
-    assert "querystring" not in dimensions_by_name
-    assert dimensions_by_name["query_hash"] == "abc"
+    assert QUERYSTRING_DIMENSION not in dimensions_by_name
+    assert dimensions_by_name[QUERY_HASH_DIMENSION] == "abc"
 
 
 def test_create_dimensions_omits_excluded_metadata_labels():
@@ -204,24 +216,22 @@ def test_cumulative_reducer_uses_sum_only_when_dimensions_are_excluded():
 
 
 def test_exclusion_uses_most_specific_metric_match_for_full_metric_skip():
-    metric_name = "cloudsql.googleapis.com/database/postgresql/insights/perquery/execution_time"
     excluded_metrics = [
-        {"metric": "cloudsql.googleapis.com/database/postgresql/insights/perquery/"},
-        {"metric": metric_name, "dimensions": {"querystring"}},
+        {"metric": PERQUERY_METRIC_PREFIX},
+        {"metric": PERQUERY_EXECUTION_TIME_METRIC, "dimensions": {QUERYSTRING_DIMENSION}},
     ]
 
-    assert should_exclude_metric(metric_name, excluded_metrics) is False
+    assert should_exclude_metric(PERQUERY_EXECUTION_TIME_METRIC, excluded_metrics) is False
 
 
 def test_exclusion_uses_most_specific_metric_match_for_dimension_skip():
-    metric_name = "cloudsql.googleapis.com/database/postgresql/insights/perquery/execution_time"
-    dimension = Dimension(key="querystring", value="label:metric.labels.querystring")
+    dimension = Dimension(key=QUERYSTRING_DIMENSION, value=QUERYSTRING_LABEL_VALUE)
     excluded_metrics = [
-        {"metric": "cloudsql.googleapis.com/database/postgresql/insights/perquery/"},
-        {"metric": metric_name, "dimensions": {"querystring"}},
+        {"metric": PERQUERY_METRIC_PREFIX},
+        {"metric": PERQUERY_EXECUTION_TIME_METRIC, "dimensions": {QUERYSTRING_DIMENSION}},
     ]
 
-    assert should_exclude_dimension(metric_name, dimension, excluded_metrics) is True
+    assert should_exclude_dimension(PERQUERY_EXECUTION_TIME_METRIC, dimension, excluded_metrics) is True
 
 
 class _FakeGcpResponse:
@@ -252,13 +262,13 @@ async def test_fetch_metric_aggregates_cumulative_metric_when_dimension_excluded
     service = GCPService(service="cloudsql_database", dimensions=[], metrics=[])
     metric = Metric(
         name="Per query execution time",
-        value="metric:cloudsql.googleapis.com/database/postgresql/insights/perquery/execution_time",
-        key="cloud.gcp.cloudsql_googleapis_com.database.postgresql.insights.perquery.execution_time.count",
+        value=f"metric:{PERQUERY_EXECUTION_TIME_METRIC}",
+        key=PERQUERY_EXECUTION_TIME_DT_METRIC,
         type="count",
         gcpOptions={"ingestDelay": 0, "samplePeriod": 60, "valueType": "INT64", "metricKind": "CUMULATIVE"},
         dimensions=[
-            {"key": "querystring", "value": "label:metric.labels.querystring"},
-            {"key": "query_hash", "value": "label:metric.labels.query_hash"},
+            {"key": QUERYSTRING_DIMENSION, "value": QUERYSTRING_LABEL_VALUE},
+            {"key": QUERY_HASH_DIMENSION, "value": QUERY_HASH_LABEL_VALUE},
         ],
     )
 
@@ -267,19 +277,18 @@ async def test_fetch_metric_aggregates_cumulative_metric_when_dimension_excluded
         "test-project",
         service,
         metric,
-        [{"metric": metric.google_metric, "dimensions": {"querystring"}}],
+        [{"metric": metric.google_metric, "dimensions": {QUERYSTRING_DIMENSION}}],
         NO_GROUPING_CATEGORY,
     )
 
     assert ("aggregation.perSeriesAligner", "ALIGN_DELTA") in gcp_session.params
     assert ("aggregation.crossSeriesReducer", "REDUCE_SUM") in gcp_session.params
-    assert ("aggregation.groupByFields", "metric.labels.querystring") not in gcp_session.params
-    assert ("aggregation.groupByFields", "metric.labels.query_hash") in gcp_session.params
+    assert (GROUP_BY_FIELDS_PARAM, QUERYSTRING_FETCH_KEY) not in gcp_session.params
+    assert (GROUP_BY_FIELDS_PARAM, QUERY_HASH_FETCH_KEY) in gcp_session.params
 
 
 @pytest.mark.asyncio
 async def test_fetch_metric_keeps_metric_when_specific_dimension_exclusion_overlaps_broad_exclusion():
-    metric_name = "cloudsql.googleapis.com/database/postgresql/insights/perquery/execution_time"
     gcp_session = _FakeGcpSession(
         {
             "timeSeries": [
@@ -287,8 +296,8 @@ async def test_fetch_metric_keeps_metric_when_specific_dimension_exclusion_overl
                     "valueType": "INT64",
                     "metric": {
                         "labels": {
-                            "querystring": "SELECT 1",
-                            "query_hash": "abc123",
+                            QUERYSTRING_DIMENSION: "SELECT 1",
+                            QUERY_HASH_DIMENSION: "abc123",
                         }
                     },
                     "resource": {"labels": {}},
@@ -307,13 +316,13 @@ async def test_fetch_metric_keeps_metric_when_specific_dimension_exclusion_overl
     service = GCPService(service="cloudsql_database", dimensions=[], metrics=[])
     metric = Metric(
         name="Per query execution time",
-        value=f"metric:{metric_name}",
-        key="cloud.gcp.cloudsql_googleapis_com.database.postgresql.insights.perquery.execution_time.count",
+        value=f"metric:{PERQUERY_EXECUTION_TIME_METRIC}",
+        key=PERQUERY_EXECUTION_TIME_DT_METRIC,
         type="count",
         gcpOptions={"ingestDelay": 0, "samplePeriod": 60, "valueType": "INT64", "metricKind": "CUMULATIVE"},
         dimensions=[
-            {"key": "querystring", "value": "label:metric.labels.querystring"},
-            {"key": "query_hash", "value": "label:metric.labels.query_hash"},
+            {"key": QUERYSTRING_DIMENSION, "value": QUERYSTRING_LABEL_VALUE},
+            {"key": QUERY_HASH_DIMENSION, "value": QUERY_HASH_LABEL_VALUE},
         ],
     )
 
@@ -323,21 +332,21 @@ async def test_fetch_metric_keeps_metric_when_specific_dimension_exclusion_overl
         service,
         metric,
         [
-            {"metric": "cloudsql.googleapis.com/database/postgresql/insights/perquery/"},
-            {"metric": metric_name, "dimensions": {"querystring"}},
+            {"metric": PERQUERY_METRIC_PREFIX},
+            {"metric": PERQUERY_EXECUTION_TIME_METRIC, "dimensions": {QUERYSTRING_DIMENSION}},
         ],
         NO_GROUPING_CATEGORY,
     )
 
     assert len(lines) == 1
-    assert lines[0].metric_name == "cloud.gcp.cloudsql_googleapis_com.database.postgresql.insights.perquery.execution_time.count"
+    assert lines[0].metric_name == PERQUERY_EXECUTION_TIME_DT_METRIC
     assert lines[0].value == 42
 
     dimensions_by_name = {dimension.name: dimension.value for dimension in lines[0].dimension_values}
-    assert "querystring" not in dimensions_by_name
-    assert dimensions_by_name["query_hash"] == "abc123"
-    assert ("aggregation.groupByFields", "metric.labels.querystring") not in gcp_session.params
-    assert ("aggregation.groupByFields", "metric.labels.query_hash") in gcp_session.params
+    assert QUERYSTRING_DIMENSION not in dimensions_by_name
+    assert dimensions_by_name[QUERY_HASH_DIMENSION] == "abc123"
+    assert (GROUP_BY_FIELDS_PARAM, QUERYSTRING_FETCH_KEY) not in gcp_session.params
+    assert (GROUP_BY_FIELDS_PARAM, QUERY_HASH_FETCH_KEY) in gcp_session.params
 
 
 def test_flatten_and_enrich_metric_results_all_additional_dimensions():

--- a/tests/unit/metrics_ingest_test.py
+++ b/tests/unit/metrics_ingest_test.py
@@ -234,6 +234,18 @@ def test_exclusion_uses_most_specific_metric_match_for_dimension_skip():
     assert should_exclude_dimension(PERQUERY_EXECUTION_TIME_METRIC, dimension, excluded_metrics) is True
 
 
+def test_exclusion_ignores_entries_without_metric_prefix():
+    dimension = Dimension(key=QUERYSTRING_DIMENSION, value=QUERYSTRING_LABEL_VALUE)
+    excluded_metrics = [
+        None,
+        {"dimensions": {QUERYSTRING_DIMENSION}},
+        {"metric": "", "dimensions": {QUERYSTRING_DIMENSION}},
+    ]
+
+    assert should_exclude_metric(PERQUERY_EXECUTION_TIME_METRIC, excluded_metrics) is False
+    assert should_exclude_dimension(PERQUERY_EXECUTION_TIME_METRIC, dimension, excluded_metrics) is False
+
+
 class _FakeGcpResponse:
     def __init__(self, body=None):
         self.body = body or {}


### PR DESCRIPTION
This pull request refactors and improves the logic for excluding metrics and dimensions in the ingestion pipeline, ensuring that the most specific exclusion rule is applied. It also adds comprehensive unit tests to verify the correct behavior of metric and dimension exclusion, particularly in cases where exclusion rules overlap.

### Refactoring and Logic Improvements

* Refactored the metric and dimension exclusion logic by introducing `find_excluded_metric`, `should_exclude_metric`, and `should_exclude_dimension` functions in `metric_ingest.py`. These functions ensure that the most specific exclusion rule is selected when multiple rules could apply, improving maintainability and correctness.
* Updated all usages of metric and dimension exclusion logic in both `metric_ingest.py` and `main.py` to use the new functions, removing duplicated and less precise logic. [[1]](diffhunk://#diff-c5626096d0344873a917f85fe0608fc810b5b6e7f86b6474ca3929cc1b328dd3L300-L315) [[2]](diffhunk://#diff-c5626096d0344873a917f85fe0608fc810b5b6e7f86b6474ca3929cc1b328dd3L347-R356) [[3]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L273-L282) [[4]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L333-R323) [[5]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L31-R31)

### Testing

* Added new unit tests in `metrics_ingest_test.py` to verify that the most specific exclusion rule is used, including cases where a metric is excluded entirely or only specific dimensions are excluded. Also added a test for overlapping exclusion rules to ensure correct behavior. [[1]](diffhunk://#diff-b4194e593d639e7aeb30a8c2c7664e4919d40bf888e0a2a48b992e076d7e4084R206-R245) [[2]](diffhunk://#diff-b4194e593d639e7aeb30a8c2c7664e4919d40bf888e0a2a48b992e076d7e4084R280-R342)
* Updated test imports to include the new exclusion functions.
* Improved test fakes to support new test cases by allowing custom response bodies.

These changes make the metric ingestion exclusion logic more robust and easier to maintain, and ensure that future changes to exclusion rules are less error-prone.