### PR TITLE
Fix cumulative metric dimension exclusions

### DIFF
--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -384,7 +384,7 @@ async def fetch_metric(
     # Ref: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors
     # Combinations: https://cloud.google.com/monitoring/api/v3/kinds-and-types#kind-type-combos
     aligner = _set_aligner(metric.google_metric_kind, metric.value_type)
-    reducer = _set_reducer(metric.google_metric_kind, metric.value_type, bool(excluded_source_dimensions))
+    reducer = _set_reducer(metric.google_metric_kind, metric.value_type)
 
     params = [
         ('filter', f'metric.type = "{metric.google_metric}" {monitoring_filter}'.strip()),
@@ -406,6 +406,12 @@ async def fetch_metric(
     should_fetch = True
 
     lines = []
+    aggregate_locally = (
+        bool(excluded_source_dimensions)
+        and metric.google_metric_kind.lower().startswith('cumulative')
+        and metric.value_type.lower() in ('int64', 'double', 'distribution')
+    )
+    aggregated_lines = {} if aggregate_locally else None
     while should_fetch:
         context.sfm[SfmKeys.gcp_metric_request_count].increment(project_id)
 
@@ -429,7 +435,10 @@ async def fetch_metric(
             for point in single_time_series['points']:
                 line = _convert_point_to_ingest_line(context, dimensions, metric, point, typed_value_key, entity_id)
                 if line:
-                    lines.append(line)
+                    if aggregate_locally:
+                        _add_aggregated_line(aggregated_lines, line, metric.value_type)
+                    else:
+                        lines.append(line)
 
         next_page_token = page.get('nextPageToken', None)
         if next_page_token:
@@ -437,7 +446,7 @@ async def fetch_metric(
         else:
             should_fetch = False
 
-    return lines
+    return list(aggregated_lines.values()) if aggregate_locally else lines
 
 
 def _set_aligner(metric_kind, value_type):
@@ -453,18 +462,59 @@ def _set_aligner(metric_kind, value_type):
     return aligner
 
 
-def _set_reducer(metric_kind, value_type, aggregate_excluded_dimensions=False):
+def _set_reducer(metric_kind, value_type):
     reducer = 'REDUCE_SUM'
 
     if metric_kind.lower().startswith('cumulative'):
-        if aggregate_excluded_dimensions and value_type.lower() in ('int64', 'double', 'distribution'):
-            reducer = 'REDUCE_SUM'
-        else:
-            reducer = 'REDUCE_NONE'
+        reducer = 'REDUCE_NONE'
     elif metric_kind.lower().startswith('gauge') and (value_type.lower() == 'int64' or value_type.lower() == 'double'):
         reducer = 'REDUCE_MEAN'
 
     return reducer
+
+
+def _add_aggregated_line(aggregated: Dict, line: IngestLine, value_type: str):
+    key = (
+        line.entity_id,
+        line.metric_name,
+        line.metric_type,
+        line.timestamp,
+        tuple(sorted(line.dimension_values, key=lambda dimension: (dimension.name, dimension.value))),
+    )
+    existing = aggregated.get(key)
+    if existing is None:
+        aggregated[key] = line
+        return
+
+    if value_type.lower() == 'distribution':
+        value = _merge_distribution_values(existing.value, line.value)
+    elif value_type.lower() == 'int64':
+        value = int(existing.value) + int(line.value)
+    elif value_type.lower() == 'double':
+        value = float(existing.value) + float(line.value)
+    else:
+        raise ValueError(f"Cannot aggregate metric value type {value_type}")
+
+    aggregated[key] = IngestLine(
+        entity_id=line.entity_id,
+        metric_name=line.metric_name,
+        metric_type=line.metric_type,
+        value=value,
+        timestamp=line.timestamp,
+        dimension_values=line.dimension_values,
+    )
+
+
+def _merge_distribution_values(first: str, second: str) -> str:
+    first_values = dict(item.split('=', 1) for item in first.split(','))
+    second_values = dict(item.split('=', 1) for item in second.split(','))
+    return _gauge_line(
+        min(float(first_values['min']), float(second_values['min'])),
+        max(float(first_values['max']), float(second_values['max'])),
+        int(first_values['count']) + int(second_values['count']),
+        float(first_values['sum']) + float(second_values['sum']),
+        None,
+    )
 
 
 def _update_params(next_page_token, params):

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -506,12 +506,8 @@ def _add_aggregated_line(aggregated: Dict, line: IngestLine, value_type: str):
 
 
 def _merge_distribution_values(first: str, second: str) -> str:
-    first_values = {
-        key: value for key, value in (item.split('=', 1) for item in first.split(','))
-    }
-    second_values = {
-        key: value for key, value in (item.split('=', 1) for item in second.split(','))
-    }
+    first_values = _parse_distribution_value(first)
+    second_values = _parse_distribution_value(second)
     return _gauge_line(
         min(float(first_values['min']), float(second_values['min'])),
         max(float(first_values['max']), float(second_values['max'])),
@@ -519,6 +515,14 @@ def _merge_distribution_values(first: str, second: str) -> str:
         float(first_values['sum']) + float(second_values['sum']),
         None,
     )
+
+
+def _parse_distribution_value(value: str) -> Dict[str, str]:
+    result = {}
+    for item in value.split(','):
+        key, item_value = item.split('=', 1)
+        result[key] = item_value
+    return result
 
 
 def _update_params(next_page_token, params):

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -506,8 +506,12 @@ def _add_aggregated_line(aggregated: Dict, line: IngestLine, value_type: str):
 
 
 def _merge_distribution_values(first: str, second: str) -> str:
-    first_values = dict(item.split('=', 1) for item in first.split(','))
-    second_values = dict(item.split('=', 1) for item in second.split(','))
+    first_values = {
+        key: value for key, value in (item.split('=', 1) for item in first.split(','))
+    }
+    second_values = {
+        key: value for key, value in (item.split('=', 1) for item in second.split(','))
+    }
     return _gauge_line(
         min(float(first_values['min']), float(second_values['min'])),
         max(float(first_values['max']), float(second_values['max'])),

--- a/tests/unit/metrics_ingest_test.py
+++ b/tests/unit/metrics_ingest_test.py
@@ -19,7 +19,7 @@ import pytest
 
 from lib.entities.model import CdProperty
 from lib.metric_ingest import *
-from lib.metric_ingest import _set_reducer
+from lib.metric_ingest import _add_aggregated_line, _set_reducer
 from lib.topology.topology import build_entity_id_map
 
 
@@ -209,10 +209,37 @@ def test_create_dimensions_omits_excluded_metadata_labels():
     assert dimensions_by_name["env"] == "prod"
 
 
-def test_cumulative_reducer_uses_sum_only_when_dimensions_are_excluded():
+def test_cumulative_reducer_does_not_aggregate_in_gcp():
     assert _set_reducer("CUMULATIVE", "INT64") == "REDUCE_NONE"
-    assert _set_reducer("CUMULATIVE", "INT64", aggregate_excluded_dimensions=True) == "REDUCE_SUM"
-    assert _set_reducer("CUMULATIVE", "DISTRIBUTION", aggregate_excluded_dimensions=True) == "REDUCE_SUM"
+
+
+def test_local_aggregation_ignores_dimension_order():
+    first = IngestLine(
+        "entity", "metric", "count", 20, 1000,
+        [DimensionValue("first", "1"), DimensionValue("second", "2")],
+    )
+    second = IngestLine(
+        "entity", "metric", "count", 22, 1000,
+        [DimensionValue("second", "2"), DimensionValue("first", "1")],
+    )
+    aggregated = {}
+
+    _add_aggregated_line(aggregated, first, "INT64")
+    _add_aggregated_line(aggregated, second, "INT64")
+
+    assert len(aggregated) == 1
+    assert next(iter(aggregated.values())).value == 42
+
+
+def test_local_aggregation_sums_double_values():
+    aggregated = {}
+    first = IngestLine("entity", "metric", "count", 1.25, 1000, [])
+    second = IngestLine("entity", "metric", "count", 2.75, 1000, [])
+
+    _add_aggregated_line(aggregated, first, "DOUBLE")
+    _add_aggregated_line(aggregated, second, "DOUBLE")
+
+    assert next(iter(aggregated.values())).value == 4.0
 
 
 def test_exclusion_uses_most_specific_metric_match_for_full_metric_skip():
@@ -268,7 +295,7 @@ class _FakeGcpSession:
 
 
 @pytest.mark.asyncio
-async def test_fetch_metric_aggregates_cumulative_metric_when_dimension_excluded():
+async def test_fetch_metric_fetches_cumulative_source_series_when_dimension_excluded():
     gcp_session = _FakeGcpSession()
     context = MetricsContext(gcp_session, None, "owner", "token", datetime.now(timezone.utc), 60, "", "", False, False, None)
     service = GCPService(service="cloudsql_database", dimensions=[], metrics=[])
@@ -294,9 +321,117 @@ async def test_fetch_metric_aggregates_cumulative_metric_when_dimension_excluded
     )
 
     assert ("aggregation.perSeriesAligner", "ALIGN_DELTA") in gcp_session.params
-    assert ("aggregation.crossSeriesReducer", "REDUCE_SUM") in gcp_session.params
+    assert ("aggregation.crossSeriesReducer", "REDUCE_NONE") in gcp_session.params
     assert (GROUP_BY_FIELDS_PARAM, QUERYSTRING_FETCH_KEY) not in gcp_session.params
     assert (GROUP_BY_FIELDS_PARAM, QUERY_HASH_FETCH_KEY) in gcp_session.params
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_aggregates_cumulative_values_after_excluding_dimension():
+    gcp_session = _FakeGcpSession(
+        {
+            "timeSeries": [
+                {
+                    "valueType": "INT64",
+                    "metric": {
+                        "labels": {
+                            QUERYSTRING_DIMENSION: querystring,
+                            QUERY_HASH_DIMENSION: "abc123",
+                        }
+                    },
+                    "resource": {"labels": {}},
+                    "metadata": {"systemLabels": {}, "userLabels": {}},
+                    "points": [
+                        {
+                            "interval": {"endTime": "2026-07-08T17:54:00Z"},
+                            "value": {"int64Value": value},
+                        }
+                    ],
+                }
+                for querystring, value in (("SELECT 1", "20"), ("SELECT 2", "22"))
+            ]
+        }
+    )
+    context = MetricsContext(gcp_session, None, "owner", "token", datetime.now(timezone.utc), 60, "", "", False, False, None)
+    service = GCPService(service="cloudsql_database", dimensions=[], metrics=[])
+    metric = Metric(
+        name="Per query execution time",
+        value=f"metric:{PERQUERY_EXECUTION_TIME_METRIC}",
+        key=PERQUERY_EXECUTION_TIME_DT_METRIC,
+        type="count",
+        gcpOptions={"ingestDelay": 0, "samplePeriod": 60, "valueType": "INT64", "metricKind": "CUMULATIVE"},
+        dimensions=[
+            {"key": QUERYSTRING_DIMENSION, "value": QUERYSTRING_LABEL_VALUE},
+            {"key": QUERY_HASH_DIMENSION, "value": QUERY_HASH_LABEL_VALUE},
+        ],
+    )
+
+    lines = await fetch_metric(
+        context,
+        "test-project",
+        service,
+        metric,
+        [{"metric": metric.google_metric, "dimensions": {QUERYSTRING_DIMENSION}}],
+        NO_GROUPING_CATEGORY,
+    )
+
+    assert len(lines) == 1
+    assert lines[0].value == 42
+    assert QUERYSTRING_DIMENSION not in {dimension.name for dimension in lines[0].dimension_values}
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_aggregates_distributions_after_excluding_dimension():
+    gcp_session = _FakeGcpSession(
+        {
+            "timeSeries": [
+                {
+                    "valueType": "DISTRIBUTION",
+                    "metric": {
+                        "labels": {
+                            QUERYSTRING_DIMENSION: querystring,
+                            QUERY_HASH_DIMENSION: "abc123",
+                        }
+                    },
+                    "resource": {"labels": {}},
+                    "metadata": {"systemLabels": {}, "userLabels": {}},
+                    "points": [
+                        {
+                            "interval": {"endTime": "2026-07-08T17:54:00Z"},
+                            "value": {"distributionValue": {"count": count, "mean": mean}},
+                        }
+                    ],
+                }
+                for querystring, count, mean in (("SELECT 1", "1", 10), ("SELECT 2", "2", 20))
+            ]
+        }
+    )
+    context = MetricsContext(gcp_session, None, "owner", "token", datetime.now(timezone.utc), 60, "", "", False, False, None)
+    service = GCPService(service="cloudsql_database", dimensions=[], metrics=[])
+    metric = Metric(
+        name="Per query latency",
+        value="metric:cloudsql.googleapis.com/database/postgresql/insights/perquery/latencies",
+        key="cloud.gcp.cloudsql_googleapis_com.database.postgresql.insights.perquery.latencies",
+        type="gauge",
+        gcpOptions={"ingestDelay": 0, "samplePeriod": 60, "valueType": "DISTRIBUTION", "metricKind": "CUMULATIVE", "unit": "us"},
+        dimensions=[
+            {"key": QUERYSTRING_DIMENSION, "value": QUERYSTRING_LABEL_VALUE},
+            {"key": QUERY_HASH_DIMENSION, "value": QUERY_HASH_LABEL_VALUE},
+        ],
+    )
+
+    lines = await fetch_metric(
+        context,
+        "test-project",
+        service,
+        metric,
+        [{"metric": metric.google_metric, "dimensions": {QUERYSTRING_DIMENSION}}],
+        NO_GROUPING_CATEGORY,
+    )
+
+    assert len(lines) == 1
+    assert lines[0].value == "min=10.0,max=20.0,count=3,sum=50.0"
+    assert QUERYSTRING_DIMENSION not in {dimension.name for dimension in lines[0].dimension_values}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep cumulative metric queries on `REDUCE_NONE` when dimensions are excluded
- remove excluded dimensions from returned series and aggregate collisions locally
- cover integer, double, distribution, and dimension-order cases

## Root cause
`release-1.7.10` used GCP `REDUCE_SUM` to aggregate away excluded dimensions. Cloud SQL PostgreSQL per-query cumulative metrics returned no usable time series with that reducer, so the metrics stopped reporting after `querystring` was excluded.

The monitor now fetches the aligned source series, removes excluded dimensions before ingest, and incrementally merges series that become identical.

